### PR TITLE
fix: make sure header must be an object schema

### DIFF
--- a/schemas/2.0.0.json
+++ b/schemas/2.0.0.json
@@ -640,7 +640,15 @@
                   "type": "string"
                 },
                 "headers": {
-                  "$ref": "#/definitions/schema"
+                  "$ref": "#/definitions/schema", 
+                  "allOf": [
+                    { "$ref": "#/definitions/schema" },
+                    { 
+                      "properties": {
+                        "type": { "const": "object" }
+                      }
+                    }
+                  ]
                 },
                 "payload": {},
                 "correlationId": {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- According to specification message headers must be defined as a schema of an object. Other types are not allowed.
- Solution based on https://json-schema.org/understanding-json-schema/reference/combining.html#id5

now validation fails with:
```
"headers": {
    "type": "integer",
    "enum": [1, 2]
}
```

but it is allowing:
```
"headers": {
    "type": "object",
    "properties": {
      "my-app-header": {
        "type": "integer",
        "minimum": 0,
        "maximum": 100
      }
    }
  }
```
**Related issue(s)**
Fixes https://github.com/asyncapi/parser-js/issues/68