### PR TITLE
fix: Schema should not enforce minProperties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .nyc_output
 .vscode
+coverage

--- a/schemas/2.0.0.json
+++ b/schemas/2.0.0.json
@@ -209,7 +209,6 @@
     "serverVariable": {
       "type": "object",
       "description": "An object representing a Server Variable for server URL template substitution.",
-      "minProperties": 1,
       "additionalProperties": false,
       "patternProperties": {
         "^x-[\\w\\d\\.\\-\\_]+$": {
@@ -479,7 +478,6 @@
           "$ref": "#/definitions/specificationExtension"
         }
       },
-      "minProperties": 1,
       "properties": {
         "$ref": {
           "$ref": "#/definitions/ReferenceObject"
@@ -1282,8 +1280,7 @@
               ]
             }
           },
-          "additionalProperties": false,
-          "minProperties": 1
+          "additionalProperties": false
         }
       },
       "patternProperties": {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Schema should not enforce minProperties. Schema is not a spec but a tool that helps to work with spec, and should not add rules not described in the spec.

**Related issue(s)**
Resolves https://github.com/asyncapi/tck/issues/30