### PR TITLE
fix: Headers fix to enforce object

### DIFF
--- a/schemas/2.0.0.json
+++ b/schemas/2.0.0.json
@@ -638,7 +638,6 @@
                   "type": "string"
                 },
                 "headers": {
-                  "$ref": "#/definitions/schema", 
                   "allOf": [
                     { "$ref": "#/definitions/schema" },
                     { 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Headers fix to enforce object

This is an issue that was supposed to be fixed already. I did those PRs in the past: https://github.com/asyncapi/asyncapi/pull/396/files and https://github.com/asyncapi/asyncapi-node/pull/10/files. As you can see the change to `asyncapi` repo was correct, but in the PR to `asyncapi-node` I made a mistake by leaving one ref 🤦 