### PR TITLE
fix: message examples definition

### DIFF
--- a/schemas/2.0.0.json
+++ b/schemas/2.0.0.json
@@ -639,10 +639,14 @@
                 },
                 "headers": {
                   "allOf": [
-                    { "$ref": "#/definitions/schema" },
-                    { 
+                    {
+                      "$ref": "#/definitions/schema"
+                    },
+                    {
                       "properties": {
-                        "type": { "const": "object" }
+                        "type": {
+                          "const": "object"
+                        }
                       }
                     }
                   ]
@@ -691,7 +695,14 @@
                 "examples": {
                   "type": "array",
                   "items": {
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "headers": {
+                        "type": "object"
+                      },
+                      "payload": {}
+                    }
                   }
                 },
                 "bindings": {


### PR DESCRIPTION
**Description**
Fixes the definition of message examples. In practice, this is gonna create a breaking change in the parser so I suggest we introduce it as soon as possible in the recently released v1.0.0.

**Related issue(s)**
https://github.com/asyncapi/asyncapi/pull/453