### PR TITLE
fix: allow extending components object with specification extensions

### DIFF
--- a/schemas/2.0.0.json
+++ b/schemas/2.0.0.json
@@ -252,6 +252,11 @@
       "type": "object",
       "description": "An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.",
       "additionalProperties": false,
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\-\\_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
       "properties": {
         "schemas": {
           "$ref": "#/definitions/schemas"


### PR DESCRIPTION
**Description**
According to the specification the components object can be extended with specification extensions. This change realizes the specified behavior

**Related issue(s)**
Fixes #46 