### PR TITLE
feat: add name and summary properties to message examples

### DIFF
--- a/schemas/2.0.0.json
+++ b/schemas/2.0.0.json
@@ -703,6 +703,14 @@
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "Name of the message example."
+                      },
+                      "summary": {
+                        "type": "string",
+                        "description": "A brief summary of the message example."
+                      },
                       "headers": {
                         "type": "object"
                       },

--- a/schemas/2.0.0.json
+++ b/schemas/2.0.0.json
@@ -702,14 +702,10 @@
                   "items": {
                     "type": "object",
                     "additionalProperties": false,
-                    "dependencies": {
-                      "name": {
-                        "required": ["payload"]
-                      },
-                      "summary": {
-                        "required": ["payload"]
-                      }
-                    },
+                    "anyOf": [
+                      {"required": ["payload"] },
+                      {"required": ["headers"] } 
+                    ],
                     "properties": {
                       "name": {
                         "type": "string",

--- a/schemas/2.0.0.json
+++ b/schemas/2.0.0.json
@@ -713,7 +713,7 @@
                     "properties": {
                       "name": {
                         "type": "string",
-                        "description": "Machine reeadable name of the message example."
+                        "description": "Machine readable name of the message example."
                       },
                       "summary": {
                         "type": "string",

--- a/schemas/2.0.0.json
+++ b/schemas/2.0.0.json
@@ -702,10 +702,18 @@
                   "items": {
                     "type": "object",
                     "additionalProperties": false,
+                    "dependencies": {
+                      "name": {
+                        "required": ["payload"]
+                      },
+                      "summary": {
+                        "required": ["payload"]
+                      }
+                    },
                     "properties": {
                       "name": {
                         "type": "string",
-                        "description": "Name of the message example."
+                        "description": "Machine reeadable name of the message example."
                       },
                       "summary": {
                         "type": "string",


### PR DESCRIPTION

**Description**

Complete message examples with `name` and `summary` attributes in order to:

* provide better documentation for examples,
* allow development of tooling leveraging examples (see Microcks.io)

This is implementing the [latest proposition](https://github.com/asyncapi/spec/issues/329#issuecomment-823993976) we had when discussing the topic. It does not introduce breaking changes and thus can be applied to current `2.0.0`.

**Related issue(s)**

This contributes to asyncapi/spec#329