### PR TITLE
feat: add new protocol bindings for IBM MQ

### DIFF
--- a/schemas/2.1.0.json
+++ b/schemas/2.1.0.json
@@ -767,7 +767,8 @@
         "sns": {},
         "sqs": {},
         "stomp": {},
-        "redis": {}
+        "redis": {},
+        "ibmmq": {}
       }
     },
     "correlationId": {


### PR DESCRIPTION
Added protocol constant that was defined in
https://github.com/asyncapi/bindings/pull/52

Contributes to: asyncapi/bindings#48

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>