### PR TITLE
fix: support for Boolean JSON Schema

### DIFF
--- a/schemas/2.0.0.json
+++ b/schemas/2.0.0.json
@@ -362,7 +362,6 @@
           "$ref": "http://json-schema.org/draft-07/schema#"
         },
         {
-          "type": "object",
           "patternProperties": {
             "^x-[\\w\\d\\.\\-\\_]+$": {
               "$ref": "#/definitions/specificationExtension"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

As in title. As we support JSON Schema draft-07 as schema, then we should also support `true/false` schemas in JSON Schema of our spec. More info https://github.com/asyncapi/parser-js/issues/232

I removed `"type": "object",` from schema, because we should infer `type` field from `"http://json-schema.org/draft-07/schema#"`. Currently we override it.

**Related issue(s)**
See more https://github.com/asyncapi/parser-js/issues/232
Blocked by https://github.com/asyncapi/spec/pull/550