### PR TITLE
ci(release): use new branch naming strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,11 +46,15 @@
     "branches": [
       "master",
       {
-        "name": "2022-04-release",
+        "name": "next-spec",
         "prerelease": true
       },
       {
         "name": "next-major-spec",
+        "prerelease": true
+      },
+      {
+        "name": "next-major",
         "prerelease": true
       }
     ],


### PR DESCRIPTION
Relates to https://github.com/asyncapi/spec/issues/734#issuecomment-1077455953

This PR changes the `package.json` file to reflect the changes on the branch naming strategy for releasing; using `next-spec` and `next-major-spec` branches, plus `next-major` in this particular case.