### PR TITLE
feat: add tags field to Server Object

### DIFF
--- a/definitions/2.5.0/server.json
+++ b/definitions/2.5.0/server.json
@@ -36,6 +36,13 @@
     },
     "bindings": {
       "$ref": "http://asyncapi.com/definitions/2.5.0/bindingsObject.json"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "http://asyncapi.com/definitions/2.5.0/tag.json"
+      },
+      "uniqueItems": true
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
**Description**

This PR adds support for defining Tags at Server Object. They can be used for providing metadata, including the environment such as `production`, `development`, etc.

**Related issue(s)**
https://github.com/asyncapi/spec/issues/654