### PR TITLE
fix: missing # prefix in JSON references in operation.json example

### DIFF
--- a/examples/3.0.0/operation.json
+++ b/examples/3.0.0/operation.json
@@ -18,7 +18,7 @@
 		}
 	},
 	"traits": [{ "$ref": "#/components/operationTraits/kafka" }],
-	"messages": [{ "$ref": "/components/messages/userSignedUp" }],
+	"messages": [{ "$ref": "#/components/messages/userSignedUp" }],
 	"reply": {
 		"address": {
 			"location": "$message.header#/replyTo"
@@ -26,6 +26,6 @@
 		"channel": {
 			"$ref": "#/channels/userSignupReply"
 		},
-		"messages": [{ "$ref": "/components/messages/userSignedUpReply" }]
+		"messages": [{ "$ref": "#/components/messages/userSignedUpReply" }]
 	}
 }]


### PR DESCRIPTION
Fixes #619

Added missing `#` prefix to 2 message $ref values in `examples/3.0.0/operation.json`:
- `/components/messages/userSignedUp` → `#/components/messages/userSignedUp`
- `/components/messages/userSignedUpReply` → `#/components/messages/userSignedUpReply`

Validates as correct JSON Reference per the spec.