### PR TITLE
fix: add missing # prefix in $ref values in operation.json example

### DIFF
--- a/examples/3.0.0/operation.json
+++ b/examples/3.0.0/operation.json
@@ -18,7 +18,7 @@
 		}
 	},
 	"traits": [{ "$ref": "#/components/operationTraits/kafka" }],
-	"messages": [{ "$ref": "/components/messages/userSignedUp" }],
+	"messages": [{ "$ref": "#/components/messages/userSignedUp" }],
 	"reply": {
 		"address": {
 			"location": "$message.header#/replyTo"
@@ -26,6 +26,6 @@
 		"channel": {
 			"$ref": "#/channels/userSignupReply"
 		},
-		"messages": [{ "$ref": "/components/messages/userSignedUpReply" }]
+		"messages": [{ "$ref": "#/components/messages/userSignedUpReply" }]
 	}
 }]


### PR DESCRIPTION
Fixes #591

The `operation.json` example was missing the `#` prefix in two `` values:
- `/components/messages/userSignedUp` → `#/components/messages/userSignedUp`
- `/components/messages/userSignedUpReply` → `#/components/messages/userSignedUpReply`

**Verification:** Inspect the file to confirm both references now use the correct JSON Pointer format with the `#` prefix.