### PR TITLE
fix: make startNewVersion script cross-platform compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "generate:assets": "npm run build",
     "prepublishOnly": "npm run build",
     "bundle": "cd tools/bundler && npm i && npm run bundle",
-    "startNewVersion": "newVersion=$npm_config_new_version node scripts/add-new-version.js",
+    "startNewVersion": "node scripts/add-new-version.js",
     "lint": "eslint --max-warnings 0 --config .eslintrc.yml .",
     "lint:fix": "eslint --max-warnings 0 --config .eslintrc.yml --fix .",
     "bump:version": "npm --no-git-tag-version --allow-same-version version $VERSION",

--- a/scripts/add-new-version.js
+++ b/scripts/add-new-version.js
@@ -4,7 +4,7 @@ const path = require('path');
  */
 const exec = require('child_process').exec;
 const fs = require('fs');
-const inputNewVersion = process.env.newVersion;
+const inputNewVersion = process.env.npm_config_new_version || process.env.newVersion;
 //Regex taken from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
 const versionRegex = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/g; //NOSONAR
 


### PR DESCRIPTION
Fixes #609

**Problem:** The `startNewVersion` npm script used Unix shell syntax (`newVersion=`) which fails on Windows CMD with `'newVersion' is not recognized`.

**Changes:**
- `package.json`: Removed shell variable assignment, script now just calls node directly
- `scripts/add-new-version.js`: Falls back to `process.env.npm_config_new_version` which npm sets automatically on all platforms

**Backward compatible:** Existing usage `npm run startNewVersion --new-version=2.7.0` works unchanged on all platforms (Unix, Windows CMD, PowerShell).

**Verification:** Run `npm run startNewVersion --new-version=3.0.0` on both Linux and Windows to confirm it executes without syntax errors.