### PR TITLE
fix: add missing # prefix in JSON refs for operation example

### DIFF
--- a/examples/3.0.0/operation.json
+++ b/examples/3.0.0/operation.json
@@ -18,7 +18,7 @@
 		}
 	},
 	"traits": [{ "$ref": "#/components/operationTraits/kafka" }],
-	"messages": [{ "$ref": "/components/messages/userSignedUp" }],
+	"messages": [{ "$ref": "#/components/messages/userSignedUp" }],
 	"reply": {
 		"address": {
 			"location": "$message.header#/replyTo"
@@ -26,6 +26,6 @@
 		"channel": {
 			"$ref": "#/channels/userSignupReply"
 		},
-		"messages": [{ "$ref": "/components/messages/userSignedUpReply" }]
+		"messages": [{ "$ref": "#/components/messages/userSignedUpReply" }]
 	}
 }]


### PR DESCRIPTION
Fixes #591

The `messages` and `reply.messages` fields in `examples/3.0.0/operation.json` were missing the `#` prefix in their JSON references.

**Changes:**
- Line 21: `"": "/components/messages/userSignedUp"` → `"": "#/components/messages/userSignedUp"`
- Line 29: `"": "/components/messages/userSignedUpReply"` → `"": "#/components/messages/userSignedUpReply"`

**Verification:** Inspect the file to confirm both $ref values now correctly start with `#/`.