### PR TITLE
chore: add missing # prefix in JSON references across examples and schemas (#619)

### DIFF
--- a/examples/3.0.0/operation.json
+++ b/examples/3.0.0/operation.json
@@ -18,7 +18,7 @@
 		}
 	},
 	"traits": [{ "$ref": "#/components/operationTraits/kafka" }],
-	"messages": [{ "$ref": "/components/messages/userSignedUp" }],
+	"messages": [{ "$ref": "#/components/messages/userSignedUp" }],
 	"reply": {
 		"address": {
 			"location": "$message.header#/replyTo"
@@ -26,6 +26,6 @@
 		"channel": {
 			"$ref": "#/channels/userSignupReply"
 		},
-		"messages": [{ "$ref": "/components/messages/userSignedUpReply" }]
+		"messages": [{ "$ref": "#/components/messages/userSignedUpReply" }]
 	}
 }]

--- a/examples/3.1.0/operation.json
+++ b/examples/3.1.0/operation.json
@@ -18,7 +18,7 @@
 		}
 	},
 	"traits": [{ "$ref": "#/components/operationTraits/kafka" }],
-	"messages": [{ "$ref": "/components/messages/userSignedUp" }],
+	"messages": [{ "$ref": "#/components/messages/userSignedUp" }],
 	"reply": {
 		"address": {
 			"location": "$message.header#/replyTo"
@@ -26,6 +26,6 @@
 		"channel": {
 			"$ref": "#/channels/userSignupReply"
 		},
-		"messages": [{ "$ref": "/components/messages/userSignedUpReply" }]
+		"messages": [{ "$ref": "#/components/messages/userSignedUpReply" }]
 	}
 }]

--- a/schemas/3.0.0-without-$id.json
+++ b/schemas/3.0.0-without-$id.json
@@ -6639,7 +6639,7 @@
                     ],
                     "messages": [
                         {
-                            "$ref": "/components/messages/userSignedUp"
+                            "$ref": "#/components/messages/userSignedUp"
                         }
                     ],
                     "reply": {
@@ -6651,7 +6651,7 @@
                         },
                         "messages": [
                             {
-                                "$ref": "/components/messages/userSignedUpReply"
+                                "$ref": "#/components/messages/userSignedUpReply"
                             }
                         ]
                     }

--- a/schemas/3.0.0.json
+++ b/schemas/3.0.0.json
@@ -6727,7 +6727,7 @@
                     ],
                     "messages": [
                         {
-                            "$ref": "/components/messages/userSignedUp"
+                            "$ref": "#/components/messages/userSignedUp"
                         }
                     ],
                     "reply": {
@@ -6739,7 +6739,7 @@
                         },
                         "messages": [
                             {
-                                "$ref": "/components/messages/userSignedUpReply"
+                                "$ref": "#/components/messages/userSignedUpReply"
                             }
                         ]
                     }

--- a/schemas/3.1.0-without-$id.json
+++ b/schemas/3.1.0-without-$id.json
@@ -7139,7 +7139,7 @@
                     ],
                     "messages": [
                         {
-                            "$ref": "/components/messages/userSignedUp"
+                            "$ref": "#/components/messages/userSignedUp"
                         }
                     ],
                     "reply": {
@@ -7151,7 +7151,7 @@
                         },
                         "messages": [
                             {
-                                "$ref": "/components/messages/userSignedUpReply"
+                                "$ref": "#/components/messages/userSignedUpReply"
                             }
                         ]
                     }

--- a/schemas/3.1.0.json
+++ b/schemas/3.1.0.json
@@ -7371,7 +7371,7 @@
                     ],
                     "messages": [
                         {
-                            "$ref": "/components/messages/userSignedUp"
+                            "$ref": "#/components/messages/userSignedUp"
                         }
                     ],
                     "reply": {
@@ -7383,7 +7383,7 @@
                         },
                         "messages": [
                             {
-                                "$ref": "/components/messages/userSignedUpReply"
+                                "$ref": "#/components/messages/userSignedUpReply"
                             }
                         ]
                     }


### PR DESCRIPTION
## Problem

**Fixes #619** (originally reported in #591)

Multiple files had `` values missing the leading `#` character, making them invalid according to JSON Reference standards:

```json
// BEFORE (invalid):
"$ref": "/components/messages/userSignedUp"

// AFTER (valid):
"$ref": "#/components/messages/userSignedUp"
```

## Files Fixed

| File | Refs Fixed |
|---|---|
| `examples/3.0.0/operation.json` | 2 |
| `examples/3.1.0/operation.json` | 2 |
| `schemas/3.0.0.json` | 2 |
| `schemas/3.0.0-without-$id.json` | 2 |
| `schemas/3.1.0.json` | 2 |
| `schemas/3.1.0-without-$id.json` | 2 |

**Total: 12 references fixed across 6 files.**

Verified: `grep -rn '$ref": "/[^#]' examples/ schemas/` returns no results.