### PR TITLE
chore: add missing # prefix to $ref values in operation.json example

### DIFF
--- a/examples/3.0.0/operation.json
+++ b/examples/3.0.0/operation.json
@@ -18,7 +18,7 @@
 		}
 	},
 	"traits": [{ "$ref": "#/components/operationTraits/kafka" }],
-	"messages": [{ "$ref": "/components/messages/userSignedUp" }],
+	"messages": [{ "$ref": "#/components/messages/userSignedUp" }],
 	"reply": {
 		"address": {
 			"location": "$message.header#/replyTo"
@@ -26,6 +26,6 @@
 		"channel": {
 			"$ref": "#/channels/userSignupReply"
 		},
-		"messages": [{ "$ref": "/components/messages/userSignedUpReply" }]
+		"messages": [{ "$ref": "#/components/messages/userSignedUpReply" }]
 	}
 }]


### PR DESCRIPTION
The $ref values for messages were missing the # prefix (e.g. `/components/messages/userSignedUp` instead of `#/components/messages/userSignedUp`), making the example document invalid according to JSON Reference standards.

Fixes asyncapi/spec-json-schemas#619