### PR TITLE
feat(kafka): flexibilize kafka bindings for clientId/groupId

### DIFF
--- a/bindings/kafka/0.6.0/channel.json
+++ b/bindings/kafka/0.6.0/channel.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/bindings/kafka/0.6.0/channel.json",
+  "title": "Channel Schema",
+  "description": "This object contains information about the channel representation in Kafka.",
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+    }
+  },
+  "properties": {
+    "topic": {
+      "type": "string",
+      "description": "Kafka topic name if different from channel name."
+    },
+    "partitions": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of partitions configured on this topic."
+    },
+    "replicas": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of replicas configured on this topic."
+    },
+    "topicConfiguration" : {
+      "description": "Topic configuration properties that are relevant for the API.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "cleanup.policy": {
+          "description": "The [`cleanup.policy`](https://kafka.apache.org/documentation/#topicconfigs_cleanup.policy) configuration option.",
+          "type": "array",
+          "items":{
+            "type": "string",
+            "enum": ["compact", "delete"]
+          }
+        },
+        "retention.ms": {
+          "description": "The [`retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_retention.ms) configuration option.",
+          "type": "integer",
+          "minimum": -1
+        },
+        "retention.bytes": {
+          "description": "The [`retention.bytes`](https://kafka.apache.org/documentation/#topicconfigs_retention.bytes) configuration option.",
+          "type": "integer",
+          "minimum": -1
+        },
+        "delete.retention.ms": {
+          "description": "The [`delete.retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_delete.retention.ms) configuration option.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "max.message.bytes": {
+          "description": "The [`max.message.bytes`](https://kafka.apache.org/documentation/#topicconfigs_max.message.bytes) configuration option.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "confluent.key.schema.validation": {
+          "description": "It shows whether the schema validation for the message key is enabled. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-key-schema-validation)",
+          "type": "boolean"
+        },
+        "confluent.key.subject.name.strategy": {
+          "description": "The name of the schema lookup strategy for the message key. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-key-subject-name-strategy)",
+          "type": "string"
+        },
+        "confluent.value.schema.validation": {
+          "description": "It shows whether the schema validation for the message value is enabled. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-value-schema-validation)",
+          "type": "boolean"
+        },
+        "confluent.value.subject.name.strategy": {
+          "description": "The name of the schema lookup strategy for the message value. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-value-subject-name-strategy)",
+          "type": "string"
+        }
+      }
+    },
+    "envServerOverrides": {
+      "type": "object",
+      "description": "A map of server name (as defined in the AsyncAPI document) to a partial channel binding object. When the named server is active, its overrides are merged onto the base channel binding.",
+      "additionalProperties": {
+        "type": "object",
+        "description": "Partial channel binding whose fields are merged onto the base kafka channel binding when the named server is active.",
+        "properties": {
+          "topic": {
+            "type": "string",
+            "description": "Kafka topic name if different from channel name."
+          },
+          "partitions": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Number of partitions configured on this topic."
+          },
+          "replicas": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Number of replicas configured on this topic."
+          },
+          "topicConfiguration": {
+            "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/channel.json#/properties/topicConfiguration"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "bindingVersion": {
+      "type": "string",
+      "enum": [
+        "0.6.0"
+      ],
+      "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+    }
+
+  },
+  "examples": [
+    {
+      "topic": "my-specific-topic",
+      "partitions": 20,
+      "replicas": 3,
+      "bindingVersion": "0.6.0"
+    },
+    {
+      "topic": "payment-events",
+      "partitions": 12,
+      "replicas": 3,
+      "topicConfiguration": {
+        "cleanup.policy": ["delete"],
+        "retention.ms": 604800000
+      },
+      "envServerOverrides": {
+        "dev": {
+          "partitions": 1,
+          "replicas": 1,
+          "topicConfiguration": {
+            "cleanup.policy": ["delete"],
+            "retention.ms": 60000
+          }
+        },
+        "staging": {
+          "partitions": 3,
+          "replicas": 2
+        }
+      },
+      "bindingVersion": "0.6.0"
+    }
+  ]
+}

--- a/bindings/kafka/0.6.0/message.json
+++ b/bindings/kafka/0.6.0/message.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/bindings/kafka/0.6.0/message.json",
+  "title": "Message Schema",
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+    }
+  },
+  "properties": {
+    "key": {
+      "oneOf": [
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+        },
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+        }
+      ],
+      "description": "The message key."
+    },
+    "schemaIdLocation": {
+      "type": "string",
+      "description": "If a Schema Registry is used when performing this operation, tells where the id of schema is stored.",
+      "enum": ["header", "payload"]
+    },
+    "schemaIdPayloadEncoding": {
+      "type": "string",
+      "description": "Number of bytes or vendor specific values when schema id is encoded in payload."
+    },
+    "schemaLookupStrategy": {
+      "type": "string",
+      "description": "Freeform string for any naming strategy class to use. Clients should default to the vendor default if not supplied."
+    },
+    "compatibility": {
+      "type": "string",
+      "enum": ["BACKWARD", "BACKWARD_TRANSITIVE", "FORWARD", "FORWARD_TRANSITIVE", "FULL", "FULL_TRANSITIVE", "NONE"],
+      "description": "The schema compatibility mode used when registering this schema with the schema registry. Values derive from compatibility types defined by Confluent Schema Registry and supported by Apicurio Registry and Karapace. MUST NOT be specified if schemaRegistryUrl is not specified at the Server level."
+    },
+    "bindingVersion": {
+      "type": "string",
+      "enum": [
+        "0.6.0"
+      ],
+      "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+    }
+
+  },
+  "examples": [
+    {
+      "key": {
+        "type": "string",
+        "enum": [
+          "myKey"
+        ]
+      },
+      "schemaIdLocation": "payload",
+      "schemaIdPayloadEncoding": "apicurio-new",
+      "schemaLookupStrategy": "TopicIdStrategy",
+      "bindingVersion": "0.6.0"
+    },
+    {
+      "key": {
+        "$ref": "path/to/user-create.avsc#/UserCreate"
+      },
+      "schemaIdLocation": "payload",
+      "schemaIdPayloadEncoding": "4",
+      "bindingVersion": "0.6.0"
+    },
+    {
+      "schemaIdLocation": "payload",
+      "schemaLookupStrategy": "TopicNameStrategy",
+      "compatibility": "BACKWARD",
+      "bindingVersion": "0.6.0"
+    }
+  ]
+}

--- a/bindings/kafka/0.6.0/operation.json
+++ b/bindings/kafka/0.6.0/operation.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/bindings/kafka/0.6.0/operation.json",
+  "title": "Operation Schema",
+  "description": "This object contains information about the operation representation in Kafka.",
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+    }
+  },
+  "properties": {
+    "groupId": {
+      "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+      "description": "Id of the consumer group."
+    },
+    "clientId": {
+      "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+      "description": "Id of the consumer inside a consumer group."
+    },
+    "transactional": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, marks this producer as transactional. The Kafka client MUST be configured with a transactional.id at runtime. Only applies to send operations."
+    },
+    "isolationLevel": {
+      "type": "string",
+      "enum": ["read_uncommitted", "read_committed"],
+      "default": "read_uncommitted",
+      "description": "Controls the visibility of transactional messages to this consumer. Use read_committed when consuming from a topic written by a transactional producer. Only applies to receive operations."
+    },
+    "errorTopics": {
+      "type": "object",
+      "description": "Configuration for retry and dead-letter queue (DLQ) topics for this consumer operation. Only applies to receive operations.",
+      "required": ["addressTemplate"],
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "required": ["retry"]
+          },
+          "then": {
+            "required": ["retryTopics"]
+          }
+        }
+      ],
+      "properties": {
+        "addressTemplate": {
+          "type": "string",
+          "description": "Template for generated topic addresses. Supports variables: ${groupId}, ${channel.address}, ${suffix} (retry-0…retry-{N-1}, dlq)."
+        },
+        "retryTopics": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of retry topics to create (named retry-0 through retry-{N-1})."
+        },
+        "retry": {
+          "description": "Topic configuration applied to each retry topic.",
+          "oneOf": [
+            {
+              "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "partitions": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Number of partitions for retry topics."
+                },
+                "replicas": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Replication factor for retry topics."
+                },
+                "topicConfiguration": {
+                  "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/channel.json#/properties/topicConfiguration"
+                }
+              }
+            }
+          ]
+        },
+        "dlq": {
+          "description": "Topic configuration applied to the DLQ topic.",
+          "oneOf": [
+            {
+              "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "partitions": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Number of partitions for the DLQ topic."
+                },
+                "replicas": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Replication factor for the DLQ topic."
+                },
+                "topicConfiguration": {
+                  "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/channel.json#/properties/topicConfiguration"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "principal": {
+      "type": "string",
+      "description": "The Kafka principal (e.g. User:bob) used to authenticate this operation. Intended for ACL documentation purposes."
+    },
+    "bindingVersion": {
+      "type": "string",
+      "enum": [
+        "0.6.0"
+      ],
+      "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+    }
+  },
+  "examples": [
+    {
+      "groupId": {
+        "type": "string",
+        "enum": [
+          "myGroupId"
+        ]
+      },
+      "clientId": {
+        "type": "string",
+        "enum": [
+          "myClientId"
+        ]
+      },
+      "bindingVersion": "0.6.0"
+    },
+    {
+      "transactional": true,
+      "principal": "User:payment-producer",
+      "bindingVersion": "0.6.0"
+    },
+    {
+      "groupId": { "type": "string", "enum": ["myGroupId"] },
+      "isolationLevel": "read_committed",
+      "errorTopics": {
+        "addressTemplate": "${groupId}.__.${channel.address}.${suffix}",
+        "retryTopics": 3,
+        "retry": {
+          "partitions": 1,
+          "replicas": 2,
+          "topicConfiguration": { "retention.ms": 259200000 }
+        },
+        "dlq": {
+          "partitions": 1,
+          "replicas": 2,
+          "topicConfiguration": {
+            "retention.ms": 2592000000,
+            "cleanup.policy": ["delete"]
+          }
+        }
+      },
+      "principal": "User:payment-consumer",
+      "bindingVersion": "0.6.0"
+    }
+  ]
+}

--- a/bindings/kafka/0.6.0/operation.json
+++ b/bindings/kafka/0.6.0/operation.json
@@ -12,11 +12,55 @@
   },
   "properties": {
     "groupId": {
-      "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        {
+          "anyOf": [
+            {
+              "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+            },
+            {
+              "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+            }
+          ]
+        }
+      ],
       "description": "Id of the consumer group."
     },
     "clientId": {
-      "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        {
+          "anyOf": [
+            {
+              "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+            },
+            {
+              "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+            }
+          ]
+        }
+      ],
       "description": "Id of the consumer inside a consumer group."
     },
     "transactional": {
@@ -125,18 +169,11 @@
   },
   "examples": [
     {
-      "groupId": {
-        "type": "string",
-        "enum": [
-          "myGroupId"
-        ]
-      },
-      "clientId": {
-        "type": "string",
-        "enum": [
-          "myClientId"
-        ]
-      },
+      "groupId": "myGroupId",
+      "clientId": [
+        "myClientId",
+        "myOtherClientId"
+      ],
       "bindingVersion": "0.6.0"
     },
     {
@@ -146,6 +183,9 @@
     },
     {
       "groupId": { "type": "string", "enum": ["myGroupId"] },
+      "clientId": {
+        "$ref": "#/components/schemas/kafkaClientId"
+      },
       "isolationLevel": "read_committed",
       "errorTopics": {
         "addressTemplate": "${groupId}.__.${channel.address}.${suffix}",

--- a/bindings/kafka/0.6.0/server.json
+++ b/bindings/kafka/0.6.0/server.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/bindings/kafka/0.6.0/server.json",
+  "title": "Server Schema",
+  "description": "This object contains server connection information to a Kafka broker. This object contains additional information not possible to represent within the core AsyncAPI specification.",
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+    }
+  },
+  "properties": {
+    "schemaRegistryUrl": {
+      "type": "string",
+      "description": "API URL for the Schema Registry used when producing Kafka messages (if a Schema Registry was used)."
+    },
+    "schemaRegistryVendor": {
+      "type": "string",
+      "description": "The vendor of the Schema Registry and Kafka serdes library that should be used."
+    },
+    "bindingVersion": {
+      "type": "string",
+      "enum": [
+        "0.6.0"
+      ],
+      "description": "The version of this binding."
+    }
+  },
+  "examples": [
+    {
+      "schemaRegistryUrl": "https://my-schema-registry.com",
+      "schemaRegistryVendor": "confluent",
+      "bindingVersion": "0.6.0"
+    }
+  ]
+}

--- a/definitions/3.0.0/channelBindingsObject.json
+++ b/definitions/3.0.0/channelBindingsObject.json
@@ -84,7 +84,7 @@
     "kafka": {
       "properties": {
         "bindingVersion": {
-          "enum": ["0.5.0", "0.4.0", "0.3.0"]
+          "enum": ["0.6.0", "0.5.0", "0.4.0", "0.3.0"]
         }
       },
       "allOf": [
@@ -98,7 +98,20 @@
             }
           },
           "then": {
-            "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/channel.json"
+            "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/channel.json"
+          }
+        },
+        {
+          "if": {
+            "required": [ "bindingVersion" ],
+            "properties": {
+              "bindingVersion": {
+                "const": "0.6.0"
+              }
+            }
+          },
+          "then": {
+            "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/channel.json"
           }
         },
         {

--- a/definitions/3.0.0/messageBindingsObject.json
+++ b/definitions/3.0.0/messageBindingsObject.json
@@ -131,7 +131,7 @@
     "kafka": {
       "properties": {
         "bindingVersion": {
-          "enum": ["0.5.0", "0.4.0", "0.3.0"]
+          "enum": ["0.6.0", "0.5.0", "0.4.0", "0.3.0"]
         }
       },
       "allOf": [
@@ -145,7 +145,20 @@
             }
           },
           "then": {
-            "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/message.json"
+            "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/message.json"
+          }
+        },
+        {
+          "if": {
+            "required": [ "bindingVersion" ],
+            "properties": {
+              "bindingVersion": {
+                "const": "0.6.0"
+              }
+            }
+          },
+          "then": {
+            "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/message.json"
           }
         },
         {

--- a/definitions/3.0.0/operationBindingsObject.json
+++ b/definitions/3.0.0/operationBindingsObject.json
@@ -131,7 +131,7 @@
     "kafka": {
       "properties": {
         "bindingVersion": {
-          "enum": ["0.5.0", "0.4.0", "0.3.0"]
+          "enum": ["0.6.0", "0.5.0", "0.4.0", "0.3.0"]
         }
       },
       "allOf": [
@@ -145,7 +145,20 @@
             }
           },
           "then": {
-            "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/operation.json"
+            "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/operation.json"
+          }
+        },
+        {
+          "if": {
+            "required": [ "bindingVersion" ],
+            "properties": {
+              "bindingVersion": {
+                "const": "0.6.0"
+              }
+            }
+          },
+          "then": {
+            "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/operation.json"
           }
         },
         {

--- a/definitions/3.0.0/serverBindingsObject.json
+++ b/definitions/3.0.0/serverBindingsObject.json
@@ -50,7 +50,7 @@
     "kafka": {
       "properties": {
         "bindingVersion": {
-          "enum": ["0.5.0", "0.4.0", "0.3.0"]
+          "enum": ["0.6.0", "0.5.0", "0.4.0", "0.3.0"]
         }
       },
       "allOf": [
@@ -64,7 +64,20 @@
             }
           },
           "then": {
-            "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/server.json"
+            "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/server.json"
+          }
+        },
+        {
+          "if": {
+            "required": [ "bindingVersion" ],
+            "properties": {
+              "bindingVersion": {
+                "const": "0.6.0"
+              }
+            }
+          },
+          "then": {
+            "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/server.json"
           }
         },
         {

--- a/definitions/3.1.0/channelBindingsObject.json
+++ b/definitions/3.1.0/channelBindingsObject.json
@@ -181,7 +181,20 @@
             }
           },
           "then": {
-            "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/channel.json"
+            "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/channel.json"
+          }
+        },
+        {
+          "if": {
+            "required": [ "bindingVersion" ],
+            "properties": {
+              "bindingVersion": {
+                "const": "0.6.0"
+              }
+            }
+          },
+          "then": {
+            "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/channel.json"
           }
         },
         {
@@ -226,7 +239,7 @@
       ],
       "properties": {
         "bindingVersion": {
-          "enum": [ "0.5.0", "0.4.0", "0.3.0" ]
+          "enum": [ "0.6.0", "0.5.0", "0.4.0", "0.3.0" ]
         }
       }
     },

--- a/definitions/3.1.0/messageBindingsObject.json
+++ b/definitions/3.1.0/messageBindingsObject.json
@@ -226,7 +226,20 @@
             }
           },
           "then": {
-            "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/message.json"
+            "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/message.json"
+          }
+        },
+        {
+          "if": {
+            "required": [ "bindingVersion" ],
+            "properties": {
+              "bindingVersion": {
+                "const": "0.6.0"
+              }
+            }
+          },
+          "then": {
+            "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/message.json"
           }
         },
         {
@@ -271,7 +284,7 @@
       ],
       "properties": {
         "bindingVersion": {
-          "enum": [ "0.5.0", "0.4.0", "0.3.0" ]
+          "enum": [ "0.6.0", "0.5.0", "0.4.0", "0.3.0" ]
         }
       }
     },

--- a/definitions/3.1.0/operationBindingsObject.json
+++ b/definitions/3.1.0/operationBindingsObject.json
@@ -98,7 +98,20 @@
             }
           },
           "then": {
-            "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/operation.json"
+            "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/operation.json"
+          }
+        },
+        {
+          "if": {
+            "required": [ "bindingVersion" ],
+            "properties": {
+              "bindingVersion": {
+                "const": "0.6.0"
+              }
+            }
+          },
+          "then": {
+            "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/operation.json"
           }
         },
         {
@@ -143,7 +156,7 @@
       ],
       "properties": {
         "bindingVersion": {
-          "enum": [ "0.5.0", "0.4.0", "0.3.0" ]
+          "enum": [ "0.6.0", "0.5.0", "0.4.0", "0.3.0" ]
         }
       }
     },

--- a/definitions/3.1.0/serverBindingsObject.json
+++ b/definitions/3.1.0/serverBindingsObject.json
@@ -85,7 +85,20 @@
             }
           },
           "then": {
-            "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/server.json"
+            "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/server.json"
+          }
+        },
+        {
+          "if": {
+            "required": [ "bindingVersion" ],
+            "properties": {
+              "bindingVersion": {
+                "const": "0.6.0"
+              }
+            }
+          },
+          "then": {
+            "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/server.json"
           }
         },
         {
@@ -130,7 +143,7 @@
       ],
       "properties": {
         "bindingVersion": {
-          "enum": [ "0.5.0", "0.4.0", "0.3.0" ]
+          "enum": [ "0.6.0", "0.5.0", "0.4.0", "0.3.0" ]
         }
       }
     },

--- a/schemas/3.0.0-without-$id.json
+++ b/schemas/3.0.0-without-$id.json
@@ -1247,6 +1247,7 @@
                     "properties": {
                         "bindingVersion": {
                             "enum": [
+                                "0.6.0",
                                 "0.5.0",
                                 "0.4.0",
                                 "0.3.0"
@@ -1264,7 +1265,22 @@
                                 }
                             },
                             "then": {
-                                "$ref": "#/definitions/bindings-kafka-0.5.0-server"
+                                "$ref": "#/definitions/bindings-kafka-0.6.0-server"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.6.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "#/definitions/bindings-kafka-0.6.0-server"
                             }
                         },
                         {
@@ -1965,6 +1981,41 @@
                 }
             },
             "default": true
+        },
+        "bindings-kafka-0.6.0-server": {
+            "title": "Server Schema",
+            "description": "This object contains server connection information to a Kafka broker. This object contains additional information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "schemaRegistryUrl": {
+                    "type": "string",
+                    "description": "API URL for the Schema Registry used when producing Kafka messages (if a Schema Registry was used)."
+                },
+                "schemaRegistryVendor": {
+                    "type": "string",
+                    "description": "The vendor of the Schema Registry and Kafka serdes library that should be used."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.6.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "schemaRegistryUrl": "https://my-schema-registry.com",
+                    "schemaRegistryVendor": "confluent",
+                    "bindingVersion": "0.6.0"
+                }
+            ]
         },
         "bindings-kafka-0.5.0-server": {
             "title": "Server Schema",
@@ -3724,6 +3775,7 @@
                     "properties": {
                         "bindingVersion": {
                             "enum": [
+                                "0.6.0",
                                 "0.5.0",
                                 "0.4.0",
                                 "0.3.0"
@@ -3741,7 +3793,22 @@
                                 }
                             },
                             "then": {
-                                "$ref": "#/definitions/bindings-kafka-0.5.0-message"
+                                "$ref": "#/definitions/bindings-kafka-0.6.0-message"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.6.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "#/definitions/bindings-kafka-0.6.0-message"
                             }
                         },
                         {
@@ -4145,6 +4212,93 @@
                     },
                     "responseTopic": "application/responses",
                     "bindingVersion": "0.2.0"
+                }
+            ]
+        },
+        "bindings-kafka-0.6.0-message": {
+            "title": "Message Schema",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "key": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Reference"
+                        },
+                        {
+                            "$ref": "#/definitions/schema"
+                        }
+                    ],
+                    "description": "The message key."
+                },
+                "schemaIdLocation": {
+                    "type": "string",
+                    "description": "If a Schema Registry is used when performing this operation, tells where the id of schema is stored.",
+                    "enum": [
+                        "header",
+                        "payload"
+                    ]
+                },
+                "schemaIdPayloadEncoding": {
+                    "type": "string",
+                    "description": "Number of bytes or vendor specific values when schema id is encoded in payload."
+                },
+                "schemaLookupStrategy": {
+                    "type": "string",
+                    "description": "Freeform string for any naming strategy class to use. Clients should default to the vendor default if not supplied."
+                },
+                "compatibility": {
+                    "type": "string",
+                    "enum": [
+                        "BACKWARD",
+                        "BACKWARD_TRANSITIVE",
+                        "FORWARD",
+                        "FORWARD_TRANSITIVE",
+                        "FULL",
+                        "FULL_TRANSITIVE",
+                        "NONE"
+                    ],
+                    "description": "The schema compatibility mode used when registering this schema with the schema registry. Values derive from compatibility types defined by Confluent Schema Registry and supported by Apicurio Registry and Karapace. MUST NOT be specified if schemaRegistryUrl is not specified at the Server level."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.6.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "key": {
+                        "type": "string",
+                        "enum": [
+                            "myKey"
+                        ]
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "apicurio-new",
+                    "schemaLookupStrategy": "TopicIdStrategy",
+                    "bindingVersion": "0.6.0"
+                },
+                {
+                    "key": {
+                        "$ref": "path/to/user-create.avsc#/UserCreate"
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "4",
+                    "bindingVersion": "0.6.0"
+                },
+                {
+                    "schemaIdLocation": "payload",
+                    "schemaLookupStrategy": "TopicNameStrategy",
+                    "compatibility": "BACKWARD",
+                    "bindingVersion": "0.6.0"
                 }
             ]
         },
@@ -4877,6 +5031,7 @@
                     "properties": {
                         "bindingVersion": {
                             "enum": [
+                                "0.6.0",
                                 "0.5.0",
                                 "0.4.0",
                                 "0.3.0"
@@ -4894,7 +5049,22 @@
                                 }
                             },
                             "then": {
-                                "$ref": "#/definitions/bindings-kafka-0.5.0-channel"
+                                "$ref": "#/definitions/bindings-kafka-0.6.0-channel"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.6.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "#/definitions/bindings-kafka-0.6.0-channel"
                             }
                         },
                         {
@@ -5423,6 +5593,158 @@
                         "vhost": "/"
                     },
                     "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "bindings-kafka-0.6.0-channel": {
+            "title": "Channel Schema",
+            "description": "This object contains information about the channel representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "topic": {
+                    "type": "string",
+                    "description": "Kafka topic name if different from channel name."
+                },
+                "partitions": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of partitions configured on this topic."
+                },
+                "replicas": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of replicas configured on this topic."
+                },
+                "topicConfiguration": {
+                    "description": "Topic configuration properties that are relevant for the API.",
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {
+                        "cleanup.policy": {
+                            "description": "The [`cleanup.policy`](https://kafka.apache.org/documentation/#topicconfigs_cleanup.policy) configuration option.",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "compact",
+                                    "delete"
+                                ]
+                            }
+                        },
+                        "retention.ms": {
+                            "description": "The [`retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_retention.ms) configuration option.",
+                            "type": "integer",
+                            "minimum": -1
+                        },
+                        "retention.bytes": {
+                            "description": "The [`retention.bytes`](https://kafka.apache.org/documentation/#topicconfigs_retention.bytes) configuration option.",
+                            "type": "integer",
+                            "minimum": -1
+                        },
+                        "delete.retention.ms": {
+                            "description": "The [`delete.retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_delete.retention.ms) configuration option.",
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "max.message.bytes": {
+                            "description": "The [`max.message.bytes`](https://kafka.apache.org/documentation/#topicconfigs_max.message.bytes) configuration option.",
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "confluent.key.schema.validation": {
+                            "description": "It shows whether the schema validation for the message key is enabled. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-key-schema-validation)",
+                            "type": "boolean"
+                        },
+                        "confluent.key.subject.name.strategy": {
+                            "description": "The name of the schema lookup strategy for the message key. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-key-subject-name-strategy)",
+                            "type": "string"
+                        },
+                        "confluent.value.schema.validation": {
+                            "description": "It shows whether the schema validation for the message value is enabled. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-value-schema-validation)",
+                            "type": "boolean"
+                        },
+                        "confluent.value.subject.name.strategy": {
+                            "description": "The name of the schema lookup strategy for the message value. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-value-subject-name-strategy)",
+                            "type": "string"
+                        }
+                    }
+                },
+                "envServerOverrides": {
+                    "type": "object",
+                    "description": "A map of server name (as defined in the AsyncAPI document) to a partial channel binding object. When the named server is active, its overrides are merged onto the base channel binding.",
+                    "additionalProperties": {
+                        "type": "object",
+                        "description": "Partial channel binding whose fields are merged onto the base kafka channel binding when the named server is active.",
+                        "properties": {
+                            "topic": {
+                                "type": "string",
+                                "description": "Kafka topic name if different from channel name."
+                            },
+                            "partitions": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "description": "Number of partitions configured on this topic."
+                            },
+                            "replicas": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "description": "Number of replicas configured on this topic."
+                            },
+                            "topicConfiguration": {
+                                "$ref": "#/definitions/bindings-kafka-0.6.0-channel/properties/topicConfiguration"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.6.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "topic": "my-specific-topic",
+                    "partitions": 20,
+                    "replicas": 3,
+                    "bindingVersion": "0.6.0"
+                },
+                {
+                    "topic": "payment-events",
+                    "partitions": 12,
+                    "replicas": 3,
+                    "topicConfiguration": {
+                        "cleanup.policy": [
+                            "delete"
+                        ],
+                        "retention.ms": 604800000
+                    },
+                    "envServerOverrides": {
+                        "dev": {
+                            "partitions": 1,
+                            "replicas": 1,
+                            "topicConfiguration": {
+                                "cleanup.policy": [
+                                    "delete"
+                                ],
+                                "retention.ms": 60000
+                            }
+                        },
+                        "staging": {
+                            "partitions": 3,
+                            "replicas": 2
+                        }
+                    },
+                    "bindingVersion": "0.6.0"
                 }
             ]
         },
@@ -6925,6 +7247,7 @@
                     "properties": {
                         "bindingVersion": {
                             "enum": [
+                                "0.6.0",
                                 "0.5.0",
                                 "0.4.0",
                                 "0.3.0"
@@ -6942,7 +7265,22 @@
                                 }
                             },
                             "then": {
-                                "$ref": "#/definitions/bindings-kafka-0.5.0-operation"
+                                "$ref": "#/definitions/bindings-kafka-0.6.0-operation"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.6.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "#/definitions/bindings-kafka-0.6.0-operation"
                             }
                         },
                         {
@@ -7479,6 +7817,193 @@
                     "retain": true,
                     "messageExpiryInterval": 60,
                     "bindingVersion": "0.2.0"
+                }
+            ]
+        },
+        "bindings-kafka-0.6.0-operation": {
+            "title": "Operation Schema",
+            "description": "This object contains information about the operation representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "groupId": {
+                    "$ref": "#/definitions/schema",
+                    "description": "Id of the consumer group."
+                },
+                "clientId": {
+                    "$ref": "#/definitions/schema",
+                    "description": "Id of the consumer inside a consumer group."
+                },
+                "transactional": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When true, marks this producer as transactional. The Kafka client MUST be configured with a transactional.id at runtime. Only applies to send operations."
+                },
+                "isolationLevel": {
+                    "type": "string",
+                    "enum": [
+                        "read_uncommitted",
+                        "read_committed"
+                    ],
+                    "default": "read_uncommitted",
+                    "description": "Controls the visibility of transactional messages to this consumer. Use read_committed when consuming from a topic written by a transactional producer. Only applies to receive operations."
+                },
+                "errorTopics": {
+                    "type": "object",
+                    "description": "Configuration for retry and dead-letter queue (DLQ) topics for this consumer operation. Only applies to receive operations.",
+                    "required": [
+                        "addressTemplate"
+                    ],
+                    "additionalProperties": false,
+                    "allOf": [
+                        {
+                            "if": {
+                                "required": [
+                                    "retry"
+                                ]
+                            },
+                            "then": {
+                                "required": [
+                                    "retryTopics"
+                                ]
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "addressTemplate": {
+                            "type": "string",
+                            "description": "Template for generated topic addresses. Supports variables: ${groupId}, ${channel.address}, ${suffix} (retry-0…retry-{N-1}, dlq)."
+                        },
+                        "retryTopics": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "description": "Number of retry topics to create (named retry-0 through retry-{N-1})."
+                        },
+                        "retry": {
+                            "description": "Topic configuration applied to each retry topic.",
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                },
+                                {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "partitions": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "description": "Number of partitions for retry topics."
+                                        },
+                                        "replicas": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "description": "Replication factor for retry topics."
+                                        },
+                                        "topicConfiguration": {
+                                            "$ref": "#/definitions/bindings-kafka-0.6.0-channel/properties/topicConfiguration"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "dlq": {
+                            "description": "Topic configuration applied to the DLQ topic.",
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                },
+                                {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "partitions": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "description": "Number of partitions for the DLQ topic."
+                                        },
+                                        "replicas": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "description": "Replication factor for the DLQ topic."
+                                        },
+                                        "topicConfiguration": {
+                                            "$ref": "#/definitions/bindings-kafka-0.6.0-channel/properties/topicConfiguration"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "principal": {
+                    "type": "string",
+                    "description": "The Kafka principal (e.g. User:bob) used to authenticate this operation. Intended for ACL documentation purposes."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.6.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "groupId": {
+                        "type": "string",
+                        "enum": [
+                            "myGroupId"
+                        ]
+                    },
+                    "clientId": {
+                        "type": "string",
+                        "enum": [
+                            "myClientId"
+                        ]
+                    },
+                    "bindingVersion": "0.6.0"
+                },
+                {
+                    "transactional": true,
+                    "principal": "User:payment-producer",
+                    "bindingVersion": "0.6.0"
+                },
+                {
+                    "groupId": {
+                        "type": "string",
+                        "enum": [
+                            "myGroupId"
+                        ]
+                    },
+                    "isolationLevel": "read_committed",
+                    "errorTopics": {
+                        "addressTemplate": "${groupId}.__.${channel.address}.${suffix}",
+                        "retryTopics": 3,
+                        "retry": {
+                            "partitions": 1,
+                            "replicas": 2,
+                            "topicConfiguration": {
+                                "retention.ms": 259200000
+                            }
+                        },
+                        "dlq": {
+                            "partitions": 1,
+                            "replicas": 2,
+                            "topicConfiguration": {
+                                "retention.ms": 2592000000,
+                                "cleanup.policy": [
+                                    "delete"
+                                ]
+                            }
+                        }
+                    },
+                    "principal": "User:payment-consumer",
+                    "bindingVersion": "0.6.0"
                 }
             ]
         },

--- a/schemas/3.0.0-without-$id.json
+++ b/schemas/3.0.0-without-$id.json
@@ -7832,11 +7832,55 @@
             },
             "properties": {
                 "groupId": {
-                    "$ref": "#/definitions/schema",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "minItems": 1,
+                            "uniqueItems": true
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/definitions/schema"
+                                },
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                }
+                            ]
+                        }
+                    ],
                     "description": "Id of the consumer group."
                 },
                 "clientId": {
-                    "$ref": "#/definitions/schema",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "minItems": 1,
+                            "uniqueItems": true
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/definitions/schema"
+                                },
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                }
+                            ]
+                        }
+                    ],
                     "description": "Id of the consumer inside a consumer group."
                 },
                 "transactional": {
@@ -7954,18 +7998,11 @@
             },
             "examples": [
                 {
-                    "groupId": {
-                        "type": "string",
-                        "enum": [
-                            "myGroupId"
-                        ]
-                    },
-                    "clientId": {
-                        "type": "string",
-                        "enum": [
-                            "myClientId"
-                        ]
-                    },
+                    "groupId": "myGroupId",
+                    "clientId": [
+                        "myClientId",
+                        "myOtherClientId"
+                    ],
                     "bindingVersion": "0.6.0"
                 },
                 {
@@ -7979,6 +8016,9 @@
                         "enum": [
                             "myGroupId"
                         ]
+                    },
+                    "clientId": {
+                        "$ref": "#/components/schemas/kafkaClientId"
                     },
                     "isolationLevel": "read_committed",
                     "errorTopics": {

--- a/schemas/3.0.0.json
+++ b/schemas/3.0.0.json
@@ -7932,11 +7932,55 @@
             },
             "properties": {
                 "groupId": {
-                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "minItems": 1,
+                            "uniqueItems": true
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                }
+                            ]
+                        }
+                    ],
                     "description": "Id of the consumer group."
                 },
                 "clientId": {
-                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "minItems": 1,
+                            "uniqueItems": true
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                }
+                            ]
+                        }
+                    ],
                     "description": "Id of the consumer inside a consumer group."
                 },
                 "transactional": {
@@ -8054,18 +8098,11 @@
             },
             "examples": [
                 {
-                    "groupId": {
-                        "type": "string",
-                        "enum": [
-                            "myGroupId"
-                        ]
-                    },
-                    "clientId": {
-                        "type": "string",
-                        "enum": [
-                            "myClientId"
-                        ]
-                    },
+                    "groupId": "myGroupId",
+                    "clientId": [
+                        "myClientId",
+                        "myOtherClientId"
+                    ],
                     "bindingVersion": "0.6.0"
                 },
                 {
@@ -8079,6 +8116,9 @@
                         "enum": [
                             "myGroupId"
                         ]
+                    },
+                    "clientId": {
+                        "$ref": "#/components/schemas/kafkaClientId"
                     },
                     "isolationLevel": "read_committed",
                     "errorTopics": {

--- a/schemas/3.0.0.json
+++ b/schemas/3.0.0.json
@@ -1283,6 +1283,7 @@
                     "properties": {
                         "bindingVersion": {
                             "enum": [
+                                "0.6.0",
                                 "0.5.0",
                                 "0.4.0",
                                 "0.3.0"
@@ -1300,7 +1301,22 @@
                                 }
                             },
                             "then": {
-                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/server.json"
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.6.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/server.json"
                             }
                         },
                         {
@@ -2004,6 +2020,42 @@
                 }
             },
             "default": true
+        },
+        "http://asyncapi.com/bindings/kafka/0.6.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.6.0/server.json",
+            "title": "Server Schema",
+            "description": "This object contains server connection information to a Kafka broker. This object contains additional information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "schemaRegistryUrl": {
+                    "type": "string",
+                    "description": "API URL for the Schema Registry used when producing Kafka messages (if a Schema Registry was used)."
+                },
+                "schemaRegistryVendor": {
+                    "type": "string",
+                    "description": "The vendor of the Schema Registry and Kafka serdes library that should be used."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.6.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "schemaRegistryUrl": "https://my-schema-registry.com",
+                    "schemaRegistryVendor": "confluent",
+                    "bindingVersion": "0.6.0"
+                }
+            ]
         },
         "http://asyncapi.com/bindings/kafka/0.5.0/server.json": {
             "$id": "http://asyncapi.com/bindings/kafka/0.5.0/server.json",
@@ -3783,6 +3835,7 @@
                     "properties": {
                         "bindingVersion": {
                             "enum": [
+                                "0.6.0",
                                 "0.5.0",
                                 "0.4.0",
                                 "0.3.0"
@@ -3800,7 +3853,22 @@
                                 }
                             },
                             "then": {
-                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/message.json"
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.6.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/message.json"
                             }
                         },
                         {
@@ -4208,6 +4276,94 @@
                     },
                     "responseTopic": "application/responses",
                     "bindingVersion": "0.2.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.6.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.6.0/message.json",
+            "title": "Message Schema",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "key": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        }
+                    ],
+                    "description": "The message key."
+                },
+                "schemaIdLocation": {
+                    "type": "string",
+                    "description": "If a Schema Registry is used when performing this operation, tells where the id of schema is stored.",
+                    "enum": [
+                        "header",
+                        "payload"
+                    ]
+                },
+                "schemaIdPayloadEncoding": {
+                    "type": "string",
+                    "description": "Number of bytes or vendor specific values when schema id is encoded in payload."
+                },
+                "schemaLookupStrategy": {
+                    "type": "string",
+                    "description": "Freeform string for any naming strategy class to use. Clients should default to the vendor default if not supplied."
+                },
+                "compatibility": {
+                    "type": "string",
+                    "enum": [
+                        "BACKWARD",
+                        "BACKWARD_TRANSITIVE",
+                        "FORWARD",
+                        "FORWARD_TRANSITIVE",
+                        "FULL",
+                        "FULL_TRANSITIVE",
+                        "NONE"
+                    ],
+                    "description": "The schema compatibility mode used when registering this schema with the schema registry. Values derive from compatibility types defined by Confluent Schema Registry and supported by Apicurio Registry and Karapace. MUST NOT be specified if schemaRegistryUrl is not specified at the Server level."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.6.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "key": {
+                        "type": "string",
+                        "enum": [
+                            "myKey"
+                        ]
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "apicurio-new",
+                    "schemaLookupStrategy": "TopicIdStrategy",
+                    "bindingVersion": "0.6.0"
+                },
+                {
+                    "key": {
+                        "$ref": "path/to/user-create.avsc#/UserCreate"
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "4",
+                    "bindingVersion": "0.6.0"
+                },
+                {
+                    "schemaIdLocation": "payload",
+                    "schemaLookupStrategy": "TopicNameStrategy",
+                    "compatibility": "BACKWARD",
+                    "bindingVersion": "0.6.0"
                 }
             ]
         },
@@ -4951,6 +5107,7 @@
                     "properties": {
                         "bindingVersion": {
                             "enum": [
+                                "0.6.0",
                                 "0.5.0",
                                 "0.4.0",
                                 "0.3.0"
@@ -4968,7 +5125,22 @@
                                 }
                             },
                             "then": {
-                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/channel.json"
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.6.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/channel.json"
                             }
                         },
                         {
@@ -5499,6 +5671,159 @@
                         "vhost": "/"
                     },
                     "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.6.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.6.0/channel.json",
+            "title": "Channel Schema",
+            "description": "This object contains information about the channel representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "topic": {
+                    "type": "string",
+                    "description": "Kafka topic name if different from channel name."
+                },
+                "partitions": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of partitions configured on this topic."
+                },
+                "replicas": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of replicas configured on this topic."
+                },
+                "topicConfiguration": {
+                    "description": "Topic configuration properties that are relevant for the API.",
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {
+                        "cleanup.policy": {
+                            "description": "The [`cleanup.policy`](https://kafka.apache.org/documentation/#topicconfigs_cleanup.policy) configuration option.",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "compact",
+                                    "delete"
+                                ]
+                            }
+                        },
+                        "retention.ms": {
+                            "description": "The [`retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_retention.ms) configuration option.",
+                            "type": "integer",
+                            "minimum": -1
+                        },
+                        "retention.bytes": {
+                            "description": "The [`retention.bytes`](https://kafka.apache.org/documentation/#topicconfigs_retention.bytes) configuration option.",
+                            "type": "integer",
+                            "minimum": -1
+                        },
+                        "delete.retention.ms": {
+                            "description": "The [`delete.retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_delete.retention.ms) configuration option.",
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "max.message.bytes": {
+                            "description": "The [`max.message.bytes`](https://kafka.apache.org/documentation/#topicconfigs_max.message.bytes) configuration option.",
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "confluent.key.schema.validation": {
+                            "description": "It shows whether the schema validation for the message key is enabled. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-key-schema-validation)",
+                            "type": "boolean"
+                        },
+                        "confluent.key.subject.name.strategy": {
+                            "description": "The name of the schema lookup strategy for the message key. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-key-subject-name-strategy)",
+                            "type": "string"
+                        },
+                        "confluent.value.schema.validation": {
+                            "description": "It shows whether the schema validation for the message value is enabled. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-value-schema-validation)",
+                            "type": "boolean"
+                        },
+                        "confluent.value.subject.name.strategy": {
+                            "description": "The name of the schema lookup strategy for the message value. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-value-subject-name-strategy)",
+                            "type": "string"
+                        }
+                    }
+                },
+                "envServerOverrides": {
+                    "type": "object",
+                    "description": "A map of server name (as defined in the AsyncAPI document) to a partial channel binding object. When the named server is active, its overrides are merged onto the base channel binding.",
+                    "additionalProperties": {
+                        "type": "object",
+                        "description": "Partial channel binding whose fields are merged onto the base kafka channel binding when the named server is active.",
+                        "properties": {
+                            "topic": {
+                                "type": "string",
+                                "description": "Kafka topic name if different from channel name."
+                            },
+                            "partitions": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "description": "Number of partitions configured on this topic."
+                            },
+                            "replicas": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "description": "Number of replicas configured on this topic."
+                            },
+                            "topicConfiguration": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/channel.json#/properties/topicConfiguration"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.6.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "topic": "my-specific-topic",
+                    "partitions": 20,
+                    "replicas": 3,
+                    "bindingVersion": "0.6.0"
+                },
+                {
+                    "topic": "payment-events",
+                    "partitions": 12,
+                    "replicas": 3,
+                    "topicConfiguration": {
+                        "cleanup.policy": [
+                            "delete"
+                        ],
+                        "retention.ms": 604800000
+                    },
+                    "envServerOverrides": {
+                        "dev": {
+                            "partitions": 1,
+                            "replicas": 1,
+                            "topicConfiguration": {
+                                "cleanup.policy": [
+                                    "delete"
+                                ],
+                                "retention.ms": 60000
+                            }
+                        },
+                        "staging": {
+                            "partitions": 3,
+                            "replicas": 2
+                        }
+                    },
+                    "bindingVersion": "0.6.0"
                 }
             ]
         },
@@ -7017,6 +7342,7 @@
                     "properties": {
                         "bindingVersion": {
                             "enum": [
+                                "0.6.0",
                                 "0.5.0",
                                 "0.4.0",
                                 "0.3.0"
@@ -7034,7 +7360,22 @@
                                 }
                             },
                             "then": {
-                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/operation.json"
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.6.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/operation.json"
                             }
                         },
                         {
@@ -7575,6 +7916,194 @@
                     "retain": true,
                     "messageExpiryInterval": 60,
                     "bindingVersion": "0.2.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.6.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.6.0/operation.json",
+            "title": "Operation Schema",
+            "description": "This object contains information about the operation representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "groupId": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "Id of the consumer group."
+                },
+                "clientId": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "Id of the consumer inside a consumer group."
+                },
+                "transactional": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When true, marks this producer as transactional. The Kafka client MUST be configured with a transactional.id at runtime. Only applies to send operations."
+                },
+                "isolationLevel": {
+                    "type": "string",
+                    "enum": [
+                        "read_uncommitted",
+                        "read_committed"
+                    ],
+                    "default": "read_uncommitted",
+                    "description": "Controls the visibility of transactional messages to this consumer. Use read_committed when consuming from a topic written by a transactional producer. Only applies to receive operations."
+                },
+                "errorTopics": {
+                    "type": "object",
+                    "description": "Configuration for retry and dead-letter queue (DLQ) topics for this consumer operation. Only applies to receive operations.",
+                    "required": [
+                        "addressTemplate"
+                    ],
+                    "additionalProperties": false,
+                    "allOf": [
+                        {
+                            "if": {
+                                "required": [
+                                    "retry"
+                                ]
+                            },
+                            "then": {
+                                "required": [
+                                    "retryTopics"
+                                ]
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "addressTemplate": {
+                            "type": "string",
+                            "description": "Template for generated topic addresses. Supports variables: ${groupId}, ${channel.address}, ${suffix} (retry-0…retry-{N-1}, dlq)."
+                        },
+                        "retryTopics": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "description": "Number of retry topics to create (named retry-0 through retry-{N-1})."
+                        },
+                        "retry": {
+                            "description": "Topic configuration applied to each retry topic.",
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "partitions": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "description": "Number of partitions for retry topics."
+                                        },
+                                        "replicas": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "description": "Replication factor for retry topics."
+                                        },
+                                        "topicConfiguration": {
+                                            "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/channel.json#/properties/topicConfiguration"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "dlq": {
+                            "description": "Topic configuration applied to the DLQ topic.",
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "partitions": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "description": "Number of partitions for the DLQ topic."
+                                        },
+                                        "replicas": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "description": "Replication factor for the DLQ topic."
+                                        },
+                                        "topicConfiguration": {
+                                            "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/channel.json#/properties/topicConfiguration"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "principal": {
+                    "type": "string",
+                    "description": "The Kafka principal (e.g. User:bob) used to authenticate this operation. Intended for ACL documentation purposes."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.6.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "groupId": {
+                        "type": "string",
+                        "enum": [
+                            "myGroupId"
+                        ]
+                    },
+                    "clientId": {
+                        "type": "string",
+                        "enum": [
+                            "myClientId"
+                        ]
+                    },
+                    "bindingVersion": "0.6.0"
+                },
+                {
+                    "transactional": true,
+                    "principal": "User:payment-producer",
+                    "bindingVersion": "0.6.0"
+                },
+                {
+                    "groupId": {
+                        "type": "string",
+                        "enum": [
+                            "myGroupId"
+                        ]
+                    },
+                    "isolationLevel": "read_committed",
+                    "errorTopics": {
+                        "addressTemplate": "${groupId}.__.${channel.address}.${suffix}",
+                        "retryTopics": 3,
+                        "retry": {
+                            "partitions": 1,
+                            "replicas": 2,
+                            "topicConfiguration": {
+                                "retention.ms": 259200000
+                            }
+                        },
+                        "dlq": {
+                            "partitions": 1,
+                            "replicas": 2,
+                            "topicConfiguration": {
+                                "retention.ms": 2592000000,
+                                "cleanup.policy": [
+                                    "delete"
+                                ]
+                            }
+                        }
+                    },
+                    "principal": "User:payment-consumer",
+                    "bindingVersion": "0.6.0"
                 }
             ]
         },

--- a/schemas/3.1.0-without-$id.json
+++ b/schemas/3.1.0-without-$id.json
@@ -431,7 +431,22 @@
                                 }
                             },
                             "then": {
-                                "$ref": "#/definitions/bindings-kafka-0.5.0-channel"
+                                "$ref": "#/definitions/bindings-kafka-0.6.0-channel"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.6.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "#/definitions/bindings-kafka-0.6.0-channel"
                             }
                         },
                         {
@@ -483,6 +498,7 @@
                     "properties": {
                         "bindingVersion": {
                             "enum": [
+                                "0.6.0",
                                 "0.5.0",
                                 "0.4.0",
                                 "0.3.0"
@@ -1102,6 +1118,158 @@
                     "destination": "user-signed-up",
                     "destinationType": "fifo-queue",
                     "bindingVersion": "0.0.1"
+                }
+            ]
+        },
+        "bindings-kafka-0.6.0-channel": {
+            "title": "Channel Schema",
+            "description": "This object contains information about the channel representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "topic": {
+                    "type": "string",
+                    "description": "Kafka topic name if different from channel name."
+                },
+                "partitions": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of partitions configured on this topic."
+                },
+                "replicas": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of replicas configured on this topic."
+                },
+                "topicConfiguration": {
+                    "description": "Topic configuration properties that are relevant for the API.",
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {
+                        "cleanup.policy": {
+                            "description": "The [`cleanup.policy`](https://kafka.apache.org/documentation/#topicconfigs_cleanup.policy) configuration option.",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "compact",
+                                    "delete"
+                                ]
+                            }
+                        },
+                        "retention.ms": {
+                            "description": "The [`retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_retention.ms) configuration option.",
+                            "type": "integer",
+                            "minimum": -1
+                        },
+                        "retention.bytes": {
+                            "description": "The [`retention.bytes`](https://kafka.apache.org/documentation/#topicconfigs_retention.bytes) configuration option.",
+                            "type": "integer",
+                            "minimum": -1
+                        },
+                        "delete.retention.ms": {
+                            "description": "The [`delete.retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_delete.retention.ms) configuration option.",
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "max.message.bytes": {
+                            "description": "The [`max.message.bytes`](https://kafka.apache.org/documentation/#topicconfigs_max.message.bytes) configuration option.",
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "confluent.key.schema.validation": {
+                            "description": "It shows whether the schema validation for the message key is enabled. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-key-schema-validation)",
+                            "type": "boolean"
+                        },
+                        "confluent.key.subject.name.strategy": {
+                            "description": "The name of the schema lookup strategy for the message key. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-key-subject-name-strategy)",
+                            "type": "string"
+                        },
+                        "confluent.value.schema.validation": {
+                            "description": "It shows whether the schema validation for the message value is enabled. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-value-schema-validation)",
+                            "type": "boolean"
+                        },
+                        "confluent.value.subject.name.strategy": {
+                            "description": "The name of the schema lookup strategy for the message value. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-value-subject-name-strategy)",
+                            "type": "string"
+                        }
+                    }
+                },
+                "envServerOverrides": {
+                    "type": "object",
+                    "description": "A map of server name (as defined in the AsyncAPI document) to a partial channel binding object. When the named server is active, its overrides are merged onto the base channel binding.",
+                    "additionalProperties": {
+                        "type": "object",
+                        "description": "Partial channel binding whose fields are merged onto the base kafka channel binding when the named server is active.",
+                        "properties": {
+                            "topic": {
+                                "type": "string",
+                                "description": "Kafka topic name if different from channel name."
+                            },
+                            "partitions": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "description": "Number of partitions configured on this topic."
+                            },
+                            "replicas": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "description": "Number of replicas configured on this topic."
+                            },
+                            "topicConfiguration": {
+                                "$ref": "#/definitions/bindings-kafka-0.6.0-channel/properties/topicConfiguration"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.6.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "topic": "my-specific-topic",
+                    "partitions": 20,
+                    "replicas": 3,
+                    "bindingVersion": "0.6.0"
+                },
+                {
+                    "topic": "payment-events",
+                    "partitions": 12,
+                    "replicas": 3,
+                    "topicConfiguration": {
+                        "cleanup.policy": [
+                            "delete"
+                        ],
+                        "retention.ms": 604800000
+                    },
+                    "envServerOverrides": {
+                        "dev": {
+                            "partitions": 1,
+                            "replicas": 1,
+                            "topicConfiguration": {
+                                "cleanup.policy": [
+                                    "delete"
+                                ],
+                                "retention.ms": 60000
+                            }
+                        },
+                        "staging": {
+                            "partitions": 3,
+                            "replicas": 2
+                        }
+                    },
+                    "bindingVersion": "0.6.0"
                 }
             ]
         },
@@ -2776,7 +2944,22 @@
                                 }
                             },
                             "then": {
-                                "$ref": "#/definitions/bindings-kafka-0.5.0-message"
+                                "$ref": "#/definitions/bindings-kafka-0.6.0-message"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.6.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "#/definitions/bindings-kafka-0.6.0-message"
                             }
                         },
                         {
@@ -2828,6 +3011,7 @@
                     "properties": {
                         "bindingVersion": {
                             "enum": [
+                                "0.6.0",
                                 "0.5.0",
                                 "0.4.0",
                                 "0.3.0"
@@ -3271,6 +3455,93 @@
                         }
                     },
                     "bindingVersion": "0.0.1"
+                }
+            ]
+        },
+        "bindings-kafka-0.6.0-message": {
+            "title": "Message Schema",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "key": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Reference"
+                        },
+                        {
+                            "$ref": "#/definitions/schema"
+                        }
+                    ],
+                    "description": "The message key."
+                },
+                "schemaIdLocation": {
+                    "type": "string",
+                    "description": "If a Schema Registry is used when performing this operation, tells where the id of schema is stored.",
+                    "enum": [
+                        "header",
+                        "payload"
+                    ]
+                },
+                "schemaIdPayloadEncoding": {
+                    "type": "string",
+                    "description": "Number of bytes or vendor specific values when schema id is encoded in payload."
+                },
+                "schemaLookupStrategy": {
+                    "type": "string",
+                    "description": "Freeform string for any naming strategy class to use. Clients should default to the vendor default if not supplied."
+                },
+                "compatibility": {
+                    "type": "string",
+                    "enum": [
+                        "BACKWARD",
+                        "BACKWARD_TRANSITIVE",
+                        "FORWARD",
+                        "FORWARD_TRANSITIVE",
+                        "FULL",
+                        "FULL_TRANSITIVE",
+                        "NONE"
+                    ],
+                    "description": "The schema compatibility mode used when registering this schema with the schema registry. Values derive from compatibility types defined by Confluent Schema Registry and supported by Apicurio Registry and Karapace. MUST NOT be specified if schemaRegistryUrl is not specified at the Server level."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.6.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "key": {
+                        "type": "string",
+                        "enum": [
+                            "myKey"
+                        ]
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "apicurio-new",
+                    "schemaLookupStrategy": "TopicIdStrategy",
+                    "bindingVersion": "0.6.0"
+                },
+                {
+                    "key": {
+                        "$ref": "path/to/user-create.avsc#/UserCreate"
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "4",
+                    "bindingVersion": "0.6.0"
+                },
+                {
+                    "schemaIdLocation": "payload",
+                    "schemaLookupStrategy": "TopicNameStrategy",
+                    "compatibility": "BACKWARD",
+                    "bindingVersion": "0.6.0"
                 }
             ]
         },
@@ -5161,7 +5432,22 @@
                                 }
                             },
                             "then": {
-                                "$ref": "#/definitions/bindings-kafka-0.5.0-operation"
+                                "$ref": "#/definitions/bindings-kafka-0.6.0-operation"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.6.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "#/definitions/bindings-kafka-0.6.0-operation"
                             }
                         },
                         {
@@ -5213,6 +5499,7 @@
                     "properties": {
                         "bindingVersion": {
                             "enum": [
+                                "0.6.0",
                                 "0.5.0",
                                 "0.4.0",
                                 "0.3.0"
@@ -5731,6 +6018,193 @@
                         "additionalProperties": false
                     },
                     "bindingVersion": "0.2.0"
+                }
+            ]
+        },
+        "bindings-kafka-0.6.0-operation": {
+            "title": "Operation Schema",
+            "description": "This object contains information about the operation representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "groupId": {
+                    "$ref": "#/definitions/schema",
+                    "description": "Id of the consumer group."
+                },
+                "clientId": {
+                    "$ref": "#/definitions/schema",
+                    "description": "Id of the consumer inside a consumer group."
+                },
+                "transactional": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When true, marks this producer as transactional. The Kafka client MUST be configured with a transactional.id at runtime. Only applies to send operations."
+                },
+                "isolationLevel": {
+                    "type": "string",
+                    "enum": [
+                        "read_uncommitted",
+                        "read_committed"
+                    ],
+                    "default": "read_uncommitted",
+                    "description": "Controls the visibility of transactional messages to this consumer. Use read_committed when consuming from a topic written by a transactional producer. Only applies to receive operations."
+                },
+                "errorTopics": {
+                    "type": "object",
+                    "description": "Configuration for retry and dead-letter queue (DLQ) topics for this consumer operation. Only applies to receive operations.",
+                    "required": [
+                        "addressTemplate"
+                    ],
+                    "additionalProperties": false,
+                    "allOf": [
+                        {
+                            "if": {
+                                "required": [
+                                    "retry"
+                                ]
+                            },
+                            "then": {
+                                "required": [
+                                    "retryTopics"
+                                ]
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "addressTemplate": {
+                            "type": "string",
+                            "description": "Template for generated topic addresses. Supports variables: ${groupId}, ${channel.address}, ${suffix} (retry-0…retry-{N-1}, dlq)."
+                        },
+                        "retryTopics": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "description": "Number of retry topics to create (named retry-0 through retry-{N-1})."
+                        },
+                        "retry": {
+                            "description": "Topic configuration applied to each retry topic.",
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                },
+                                {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "partitions": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "description": "Number of partitions for retry topics."
+                                        },
+                                        "replicas": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "description": "Replication factor for retry topics."
+                                        },
+                                        "topicConfiguration": {
+                                            "$ref": "#/definitions/bindings-kafka-0.6.0-channel/properties/topicConfiguration"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "dlq": {
+                            "description": "Topic configuration applied to the DLQ topic.",
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                },
+                                {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "partitions": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "description": "Number of partitions for the DLQ topic."
+                                        },
+                                        "replicas": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "description": "Replication factor for the DLQ topic."
+                                        },
+                                        "topicConfiguration": {
+                                            "$ref": "#/definitions/bindings-kafka-0.6.0-channel/properties/topicConfiguration"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "principal": {
+                    "type": "string",
+                    "description": "The Kafka principal (e.g. User:bob) used to authenticate this operation. Intended for ACL documentation purposes."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.6.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "groupId": {
+                        "type": "string",
+                        "enum": [
+                            "myGroupId"
+                        ]
+                    },
+                    "clientId": {
+                        "type": "string",
+                        "enum": [
+                            "myClientId"
+                        ]
+                    },
+                    "bindingVersion": "0.6.0"
+                },
+                {
+                    "transactional": true,
+                    "principal": "User:payment-producer",
+                    "bindingVersion": "0.6.0"
+                },
+                {
+                    "groupId": {
+                        "type": "string",
+                        "enum": [
+                            "myGroupId"
+                        ]
+                    },
+                    "isolationLevel": "read_committed",
+                    "errorTopics": {
+                        "addressTemplate": "${groupId}.__.${channel.address}.${suffix}",
+                        "retryTopics": 3,
+                        "retry": {
+                            "partitions": 1,
+                            "replicas": 2,
+                            "topicConfiguration": {
+                                "retention.ms": 259200000
+                            }
+                        },
+                        "dlq": {
+                            "partitions": 1,
+                            "replicas": 2,
+                            "topicConfiguration": {
+                                "retention.ms": 2592000000,
+                                "cleanup.policy": [
+                                    "delete"
+                                ]
+                            }
+                        }
+                    },
+                    "principal": "User:payment-consumer",
+                    "bindingVersion": "0.6.0"
                 }
             ]
         },
@@ -7964,7 +8438,22 @@
                                 }
                             },
                             "then": {
-                                "$ref": "#/definitions/bindings-kafka-0.5.0-server"
+                                "$ref": "#/definitions/bindings-kafka-0.6.0-server"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.6.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "#/definitions/bindings-kafka-0.6.0-server"
                             }
                         },
                         {
@@ -8016,6 +8505,7 @@
                     "properties": {
                         "bindingVersion": {
                             "enum": [
+                                "0.6.0",
                                 "0.5.0",
                                 "0.4.0",
                                 "0.3.0"
@@ -8353,6 +8843,41 @@
                     ],
                     "clientID": "my-application-1",
                     "bindingVersion": "0.0.1"
+                }
+            ]
+        },
+        "bindings-kafka-0.6.0-server": {
+            "title": "Server Schema",
+            "description": "This object contains server connection information to a Kafka broker. This object contains additional information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "schemaRegistryUrl": {
+                    "type": "string",
+                    "description": "API URL for the Schema Registry used when producing Kafka messages (if a Schema Registry was used)."
+                },
+                "schemaRegistryVendor": {
+                    "type": "string",
+                    "description": "The vendor of the Schema Registry and Kafka serdes library that should be used."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.6.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "schemaRegistryUrl": "https://my-schema-registry.com",
+                    "schemaRegistryVendor": "confluent",
+                    "bindingVersion": "0.6.0"
                 }
             ]
         },

--- a/schemas/3.1.0-without-$id.json
+++ b/schemas/3.1.0-without-$id.json
@@ -6033,11 +6033,55 @@
             },
             "properties": {
                 "groupId": {
-                    "$ref": "#/definitions/schema",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "minItems": 1,
+                            "uniqueItems": true
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/definitions/schema"
+                                },
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                }
+                            ]
+                        }
+                    ],
                     "description": "Id of the consumer group."
                 },
                 "clientId": {
-                    "$ref": "#/definitions/schema",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "minItems": 1,
+                            "uniqueItems": true
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/definitions/schema"
+                                },
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                }
+                            ]
+                        }
+                    ],
                     "description": "Id of the consumer inside a consumer group."
                 },
                 "transactional": {
@@ -6155,18 +6199,11 @@
             },
             "examples": [
                 {
-                    "groupId": {
-                        "type": "string",
-                        "enum": [
-                            "myGroupId"
-                        ]
-                    },
-                    "clientId": {
-                        "type": "string",
-                        "enum": [
-                            "myClientId"
-                        ]
-                    },
+                    "groupId": "myGroupId",
+                    "clientId": [
+                        "myClientId",
+                        "myOtherClientId"
+                    ],
                     "bindingVersion": "0.6.0"
                 },
                 {
@@ -6180,6 +6217,9 @@
                         "enum": [
                             "myGroupId"
                         ]
+                    },
+                    "clientId": {
+                        "$ref": "#/components/schemas/kafkaClientId"
                     },
                     "isolationLevel": "read_committed",
                     "errorTopics": {

--- a/schemas/3.1.0.json
+++ b/schemas/3.1.0.json
@@ -437,7 +437,22 @@
                                 }
                             },
                             "then": {
-                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/channel.json"
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.6.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/channel.json"
                             }
                         },
                         {
@@ -489,6 +504,7 @@
                     "properties": {
                         "bindingVersion": {
                             "enum": [
+                                "0.6.0",
                                 "0.5.0",
                                 "0.4.0",
                                 "0.3.0"
@@ -1114,6 +1130,159 @@
                     "destination": "user-signed-up",
                     "destinationType": "fifo-queue",
                     "bindingVersion": "0.0.1"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.6.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.6.0/channel.json",
+            "title": "Channel Schema",
+            "description": "This object contains information about the channel representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "topic": {
+                    "type": "string",
+                    "description": "Kafka topic name if different from channel name."
+                },
+                "partitions": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of partitions configured on this topic."
+                },
+                "replicas": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of replicas configured on this topic."
+                },
+                "topicConfiguration": {
+                    "description": "Topic configuration properties that are relevant for the API.",
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {
+                        "cleanup.policy": {
+                            "description": "The [`cleanup.policy`](https://kafka.apache.org/documentation/#topicconfigs_cleanup.policy) configuration option.",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "compact",
+                                    "delete"
+                                ]
+                            }
+                        },
+                        "retention.ms": {
+                            "description": "The [`retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_retention.ms) configuration option.",
+                            "type": "integer",
+                            "minimum": -1
+                        },
+                        "retention.bytes": {
+                            "description": "The [`retention.bytes`](https://kafka.apache.org/documentation/#topicconfigs_retention.bytes) configuration option.",
+                            "type": "integer",
+                            "minimum": -1
+                        },
+                        "delete.retention.ms": {
+                            "description": "The [`delete.retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_delete.retention.ms) configuration option.",
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "max.message.bytes": {
+                            "description": "The [`max.message.bytes`](https://kafka.apache.org/documentation/#topicconfigs_max.message.bytes) configuration option.",
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "confluent.key.schema.validation": {
+                            "description": "It shows whether the schema validation for the message key is enabled. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-key-schema-validation)",
+                            "type": "boolean"
+                        },
+                        "confluent.key.subject.name.strategy": {
+                            "description": "The name of the schema lookup strategy for the message key. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-key-subject-name-strategy)",
+                            "type": "string"
+                        },
+                        "confluent.value.schema.validation": {
+                            "description": "It shows whether the schema validation for the message value is enabled. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-value-schema-validation)",
+                            "type": "boolean"
+                        },
+                        "confluent.value.subject.name.strategy": {
+                            "description": "The name of the schema lookup strategy for the message value. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-value-subject-name-strategy)",
+                            "type": "string"
+                        }
+                    }
+                },
+                "envServerOverrides": {
+                    "type": "object",
+                    "description": "A map of server name (as defined in the AsyncAPI document) to a partial channel binding object. When the named server is active, its overrides are merged onto the base channel binding.",
+                    "additionalProperties": {
+                        "type": "object",
+                        "description": "Partial channel binding whose fields are merged onto the base kafka channel binding when the named server is active.",
+                        "properties": {
+                            "topic": {
+                                "type": "string",
+                                "description": "Kafka topic name if different from channel name."
+                            },
+                            "partitions": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "description": "Number of partitions configured on this topic."
+                            },
+                            "replicas": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "description": "Number of replicas configured on this topic."
+                            },
+                            "topicConfiguration": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/channel.json#/properties/topicConfiguration"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.6.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "topic": "my-specific-topic",
+                    "partitions": 20,
+                    "replicas": 3,
+                    "bindingVersion": "0.6.0"
+                },
+                {
+                    "topic": "payment-events",
+                    "partitions": 12,
+                    "replicas": 3,
+                    "topicConfiguration": {
+                        "cleanup.policy": [
+                            "delete"
+                        ],
+                        "retention.ms": 604800000
+                    },
+                    "envServerOverrides": {
+                        "dev": {
+                            "partitions": 1,
+                            "replicas": 1,
+                            "topicConfiguration": {
+                                "cleanup.policy": [
+                                    "delete"
+                                ],
+                                "retention.ms": 60000
+                            }
+                        },
+                        "staging": {
+                            "partitions": 3,
+                            "replicas": 2
+                        }
+                    },
+                    "bindingVersion": "0.6.0"
                 }
             ]
         },
@@ -2863,7 +3032,22 @@
                                 }
                             },
                             "then": {
-                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/message.json"
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.6.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/message.json"
                             }
                         },
                         {
@@ -2915,6 +3099,7 @@
                     "properties": {
                         "bindingVersion": {
                             "enum": [
+                                "0.6.0",
                                 "0.5.0",
                                 "0.4.0",
                                 "0.3.0"
@@ -3365,6 +3550,94 @@
                         }
                     },
                     "bindingVersion": "0.0.1"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.6.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.6.0/message.json",
+            "title": "Message Schema",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "key": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        }
+                    ],
+                    "description": "The message key."
+                },
+                "schemaIdLocation": {
+                    "type": "string",
+                    "description": "If a Schema Registry is used when performing this operation, tells where the id of schema is stored.",
+                    "enum": [
+                        "header",
+                        "payload"
+                    ]
+                },
+                "schemaIdPayloadEncoding": {
+                    "type": "string",
+                    "description": "Number of bytes or vendor specific values when schema id is encoded in payload."
+                },
+                "schemaLookupStrategy": {
+                    "type": "string",
+                    "description": "Freeform string for any naming strategy class to use. Clients should default to the vendor default if not supplied."
+                },
+                "compatibility": {
+                    "type": "string",
+                    "enum": [
+                        "BACKWARD",
+                        "BACKWARD_TRANSITIVE",
+                        "FORWARD",
+                        "FORWARD_TRANSITIVE",
+                        "FULL",
+                        "FULL_TRANSITIVE",
+                        "NONE"
+                    ],
+                    "description": "The schema compatibility mode used when registering this schema with the schema registry. Values derive from compatibility types defined by Confluent Schema Registry and supported by Apicurio Registry and Karapace. MUST NOT be specified if schemaRegistryUrl is not specified at the Server level."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.6.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "key": {
+                        "type": "string",
+                        "enum": [
+                            "myKey"
+                        ]
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "apicurio-new",
+                    "schemaLookupStrategy": "TopicIdStrategy",
+                    "bindingVersion": "0.6.0"
+                },
+                {
+                    "key": {
+                        "$ref": "path/to/user-create.avsc#/UserCreate"
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "4",
+                    "bindingVersion": "0.6.0"
+                },
+                {
+                    "schemaIdLocation": "payload",
+                    "schemaLookupStrategy": "TopicNameStrategy",
+                    "compatibility": "BACKWARD",
+                    "bindingVersion": "0.6.0"
                 }
             ]
         },
@@ -5377,7 +5650,22 @@
                                 }
                             },
                             "then": {
-                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/operation.json"
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.6.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/operation.json"
                             }
                         },
                         {
@@ -5429,6 +5717,7 @@
                     "properties": {
                         "bindingVersion": {
                             "enum": [
+                                "0.6.0",
                                 "0.5.0",
                                 "0.4.0",
                                 "0.3.0"
@@ -5950,6 +6239,194 @@
                         "additionalProperties": false
                     },
                     "bindingVersion": "0.2.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.6.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.6.0/operation.json",
+            "title": "Operation Schema",
+            "description": "This object contains information about the operation representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "groupId": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "Id of the consumer group."
+                },
+                "clientId": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "Id of the consumer inside a consumer group."
+                },
+                "transactional": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When true, marks this producer as transactional. The Kafka client MUST be configured with a transactional.id at runtime. Only applies to send operations."
+                },
+                "isolationLevel": {
+                    "type": "string",
+                    "enum": [
+                        "read_uncommitted",
+                        "read_committed"
+                    ],
+                    "default": "read_uncommitted",
+                    "description": "Controls the visibility of transactional messages to this consumer. Use read_committed when consuming from a topic written by a transactional producer. Only applies to receive operations."
+                },
+                "errorTopics": {
+                    "type": "object",
+                    "description": "Configuration for retry and dead-letter queue (DLQ) topics for this consumer operation. Only applies to receive operations.",
+                    "required": [
+                        "addressTemplate"
+                    ],
+                    "additionalProperties": false,
+                    "allOf": [
+                        {
+                            "if": {
+                                "required": [
+                                    "retry"
+                                ]
+                            },
+                            "then": {
+                                "required": [
+                                    "retryTopics"
+                                ]
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "addressTemplate": {
+                            "type": "string",
+                            "description": "Template for generated topic addresses. Supports variables: ${groupId}, ${channel.address}, ${suffix} (retry-0…retry-{N-1}, dlq)."
+                        },
+                        "retryTopics": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "description": "Number of retry topics to create (named retry-0 through retry-{N-1})."
+                        },
+                        "retry": {
+                            "description": "Topic configuration applied to each retry topic.",
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "partitions": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "description": "Number of partitions for retry topics."
+                                        },
+                                        "replicas": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "description": "Replication factor for retry topics."
+                                        },
+                                        "topicConfiguration": {
+                                            "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/channel.json#/properties/topicConfiguration"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "dlq": {
+                            "description": "Topic configuration applied to the DLQ topic.",
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "partitions": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "description": "Number of partitions for the DLQ topic."
+                                        },
+                                        "replicas": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "description": "Replication factor for the DLQ topic."
+                                        },
+                                        "topicConfiguration": {
+                                            "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/channel.json#/properties/topicConfiguration"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "principal": {
+                    "type": "string",
+                    "description": "The Kafka principal (e.g. User:bob) used to authenticate this operation. Intended for ACL documentation purposes."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.6.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "groupId": {
+                        "type": "string",
+                        "enum": [
+                            "myGroupId"
+                        ]
+                    },
+                    "clientId": {
+                        "type": "string",
+                        "enum": [
+                            "myClientId"
+                        ]
+                    },
+                    "bindingVersion": "0.6.0"
+                },
+                {
+                    "transactional": true,
+                    "principal": "User:payment-producer",
+                    "bindingVersion": "0.6.0"
+                },
+                {
+                    "groupId": {
+                        "type": "string",
+                        "enum": [
+                            "myGroupId"
+                        ]
+                    },
+                    "isolationLevel": "read_committed",
+                    "errorTopics": {
+                        "addressTemplate": "${groupId}.__.${channel.address}.${suffix}",
+                        "retryTopics": 3,
+                        "retry": {
+                            "partitions": 1,
+                            "replicas": 2,
+                            "topicConfiguration": {
+                                "retention.ms": 259200000
+                            }
+                        },
+                        "dlq": {
+                            "partitions": 1,
+                            "replicas": 2,
+                            "topicConfiguration": {
+                                "retention.ms": 2592000000,
+                                "cleanup.policy": [
+                                    "delete"
+                                ]
+                            }
+                        }
+                    },
+                    "principal": "User:payment-consumer",
+                    "bindingVersion": "0.6.0"
                 }
             ]
         },
@@ -8218,7 +8695,22 @@
                                 }
                             },
                             "then": {
-                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/server.json"
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.6.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.6.0/server.json"
                             }
                         },
                         {
@@ -8270,6 +8762,7 @@
                     "properties": {
                         "bindingVersion": {
                             "enum": [
+                                "0.6.0",
                                 "0.5.0",
                                 "0.4.0",
                                 "0.3.0"
@@ -8609,6 +9102,42 @@
                     ],
                     "clientID": "my-application-1",
                     "bindingVersion": "0.0.1"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.6.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.6.0/server.json",
+            "title": "Server Schema",
+            "description": "This object contains server connection information to a Kafka broker. This object contains additional information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "schemaRegistryUrl": {
+                    "type": "string",
+                    "description": "API URL for the Schema Registry used when producing Kafka messages (if a Schema Registry was used)."
+                },
+                "schemaRegistryVendor": {
+                    "type": "string",
+                    "description": "The vendor of the Schema Registry and Kafka serdes library that should be used."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.6.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "schemaRegistryUrl": "https://my-schema-registry.com",
+                    "schemaRegistryVendor": "confluent",
+                    "bindingVersion": "0.6.0"
                 }
             ]
         },

--- a/schemas/3.1.0.json
+++ b/schemas/3.1.0.json
@@ -6255,11 +6255,55 @@
             },
             "properties": {
                 "groupId": {
-                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "minItems": 1,
+                            "uniqueItems": true
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                }
+                            ]
+                        }
+                    ],
                     "description": "Id of the consumer group."
                 },
                 "clientId": {
-                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "minItems": 1,
+                            "uniqueItems": true
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                }
+                            ]
+                        }
+                    ],
                     "description": "Id of the consumer inside a consumer group."
                 },
                 "transactional": {
@@ -6377,18 +6421,11 @@
             },
             "examples": [
                 {
-                    "groupId": {
-                        "type": "string",
-                        "enum": [
-                            "myGroupId"
-                        ]
-                    },
-                    "clientId": {
-                        "type": "string",
-                        "enum": [
-                            "myClientId"
-                        ]
-                    },
+                    "groupId": "myGroupId",
+                    "clientId": [
+                        "myClientId",
+                        "myOtherClientId"
+                    ],
                     "bindingVersion": "0.6.0"
                 },
                 {
@@ -6402,6 +6439,9 @@
                         "enum": [
                             "myGroupId"
                         ]
+                    },
+                    "clientId": {
+                        "$ref": "#/components/schemas/kafkaClientId"
                     },
                     "isolationLevel": "read_committed",
                     "errorTopics": {

--- a/test/ajv-schemes.js
+++ b/test/ajv-schemes.js
@@ -45,6 +45,10 @@ function bindingSchemes(ajv) {
   ajv.addSchema(require('@bindings/kafka/0.5.0/message.json'));
   ajv.addSchema(require('@bindings/kafka/0.5.0/operation.json'));
   ajv.addSchema(require('@bindings/kafka/0.5.0/server.json'));
+  ajv.addSchema(require('@bindings/kafka/0.6.0/channel.json'));
+  ajv.addSchema(require('@bindings/kafka/0.6.0/message.json'));
+  ajv.addSchema(require('@bindings/kafka/0.6.0/operation.json'));
+  ajv.addSchema(require('@bindings/kafka/0.6.0/server.json'));
 
   ajv.addSchema(require('@bindings/mqtt/0.1.0/message.json'));
   ajv.addSchema(require('@bindings/mqtt/0.1.0/operation.json'));

--- a/test/bindings/kafka/kafka channel binding.test.mjs
+++ b/test/bindings/kafka/kafka channel binding.test.mjs
@@ -3,7 +3,8 @@ import {
   JsonSchemaTestSuiteConfig,
   JsonSchemaTestSuiteData
 } from '@test/definitions/base-schema-test.mjs';
-import {describe} from 'vitest';
+import TestHelper from '@test/test-helper';
+import {describe, it} from 'vitest';
 
 const config = new JsonSchemaTestSuiteConfig(
   false,
@@ -114,12 +115,86 @@ let data = {
       "ext-number": 1
     }
   ),
+  "0.6.0": new JsonSchemaTestSuiteData(
+    require(`@bindings/kafka/0.6.0/channel.json`),
+    [
+      {
+        "topic": "my-specific-topic-name",
+        "partitions": 20,
+        "replicas": 3,
+        "topicConfiguration": {
+          "cleanup.policy": [
+            "delete",
+            "compact"
+          ],
+          "retention.ms": 604800000
+        },
+        "bindingVersion": "0.6.0"
+      },
+      {
+        "partitions": 12,
+        "replicas": 3,
+        "envServerOverrides": {
+          "dev": {
+            "partitions": 1,
+            "replicas": 1,
+            "topicConfiguration": {
+              "cleanup.policy": ["delete"],
+              "retention.ms": 60000
+            }
+          },
+          "staging": {
+            "partitions": 3,
+            "replicas": 2
+          }
+        },
+        "bindingVersion": "0.6.0"
+      }
+    ],
+    {},
+    {},
+    {
+      "x-number": 0,
+      "x-string": "",
+      "x-object": {
+        "property": {}
+      }
+    },
+    {
+      "x-number": 0,
+      "x-string": "",
+      "x-object": {
+        "property": {}
+      },
+      "ext-number": 1
+    }
+  ),
 }
 
 describe.each([
   '0.3.0',
   '0.4.0',
   '0.5.0',
+  '0.6.0',
 ])('Kafka channel binding v%s', (bindingVersion) => {
   new JsonSchemaTestSuite(data[bindingVersion], config).testSuite()
+})
+
+describe('Kafka channel binding v0.6.0 bindingVersion', () => {
+  const schema = require(`@bindings/kafka/0.6.0/channel.json`);
+
+  it('rejects previous bindingVersion values', () => TestHelper.objectIsNotValid(
+    schema,
+    {
+      "envServerOverrides": {
+        "dev": {
+          "partitions": 1
+        }
+      },
+      "bindingVersion": "0.5.0"
+    },
+    [
+      "must be equal to one of the allowed values"
+    ]
+  ));
 })

--- a/test/bindings/kafka/kafka message binding.test.mjs
+++ b/test/bindings/kafka/kafka message binding.test.mjs
@@ -3,7 +3,8 @@ import {
   JsonSchemaTestSuiteConfig,
   JsonSchemaTestSuiteData
 } from '@test/definitions/base-schema-test.mjs';
-import {describe} from 'vitest';
+import TestHelper from '@test/test-helper';
+import {describe, it} from 'vitest';
 
 const config = new JsonSchemaTestSuiteConfig(
   false,
@@ -142,6 +143,46 @@ let data = {
       "ext-number": 1
     }
   ),
+  "0.6.0": new JsonSchemaTestSuiteData(
+    require(`@bindings/kafka/0.6.0/message.json`),
+    [
+      {
+        "key": {
+          "type": "string",
+          "enum": [
+            "myKey"
+          ]
+        },
+        "schemaIdLocation": "payload",
+        "schemaIdPayloadEncoding": "apicurio-new",
+        "schemaLookupStrategy": "TopicIdStrategy",
+        "bindingVersion": "0.6.0"
+      },
+      {
+        "schemaIdLocation": "payload",
+        "schemaLookupStrategy": "TopicNameStrategy",
+        "compatibility": "BACKWARD",
+        "bindingVersion": "0.6.0"
+      }
+    ],
+    {},
+    {},
+    {
+      "x-number": 0,
+      "x-string": "",
+      "x-object": {
+        "property": {}
+      }
+    },
+    {
+      "x-number": 0,
+      "x-string": "",
+      "x-object": {
+        "property": {}
+      },
+      "ext-number": 1
+    }
+  ),
 }
 
 describe.each([
@@ -149,6 +190,22 @@ describe.each([
   '0.3.0',
   '0.4.0',
   '0.5.0',
+  '0.6.0',
 ])('Kafka message binding v%s', (bindingVersion) => {
   new JsonSchemaTestSuite(data[bindingVersion], config).testSuite()
+})
+
+describe('Kafka message binding v0.6.0 bindingVersion', () => {
+  const schema = require(`@bindings/kafka/0.6.0/message.json`);
+
+  it('rejects previous bindingVersion values', () => TestHelper.objectIsNotValid(
+    schema,
+    {
+      "compatibility": "BACKWARD",
+      "bindingVersion": "0.5.0"
+    },
+    [
+      "must be equal to one of the allowed values"
+    ]
+  ));
 })

--- a/test/bindings/kafka/kafka operation binding.test.mjs
+++ b/test/bindings/kafka/kafka operation binding.test.mjs
@@ -3,7 +3,10 @@ import {
   JsonSchemaTestSuiteConfig,
   JsonSchemaTestSuiteData
 } from '@test/definitions/base-schema-test.mjs';
-import {describe} from 'vitest';
+import TestHelper from '@test/test-helper';
+import {describe, it} from 'vitest';
+
+const assert = require('assert');
 
 const config = new JsonSchemaTestSuiteConfig(
   false,
@@ -157,6 +160,76 @@ let data = {
       "ext-number": 1
     }
   ),
+  "0.6.0": new JsonSchemaTestSuiteData(
+    require(`@bindings/kafka/0.6.0/operation.json`),
+    [
+      {
+        "groupId": {
+          "type": "string",
+          "enum": [
+            "myGroupId"
+          ]
+        },
+        "clientId": {
+          "type": "string",
+          "enum": [
+            "myClientId"
+          ]
+        },
+        "bindingVersion": "0.6.0"
+      },
+      {
+        "transactional": true,
+        "principal": "User:payment-producer",
+        "bindingVersion": "0.6.0"
+      },
+      {
+        "groupId": {
+          "type": "string",
+          "enum": [
+            "myGroupId"
+          ]
+        },
+        "isolationLevel": "read_committed",
+        "errorTopics": {
+          "addressTemplate": "${groupId}.__.${channel.address}.${suffix}",
+          "retryTopics": 3,
+          "retry": {
+            "partitions": 1,
+            "replicas": 2,
+            "topicConfiguration": { "retention.ms": 259200000 }
+          },
+          "dlq": {
+            "partitions": 1,
+            "replicas": 2,
+            "topicConfiguration": {
+              "retention.ms": 2592000000,
+              "cleanup.policy": ["delete"]
+            }
+          }
+        },
+        "principal": "User:payment-consumer",
+        "bindingVersion": "0.6.0"
+      }
+    ],
+    {},
+    {},
+    {
+      "x-number": 0,
+      "x-string": "",
+      "x-object": {
+        "property": {}
+      }
+    },
+    {
+      "x-number": 0,
+      "x-string": "",
+      "x-object": {
+        "property": {}
+      },
+      "ext-number": 1
+    }
+  ),
 }
 
 describe.each([
@@ -164,6 +237,59 @@ describe.each([
   '0.3.0',
   '0.4.0',
   '0.5.0',
+  '0.6.0',
 ])('Kafka operation binding v%s', (bindingVersion) => {
   new JsonSchemaTestSuite(data[bindingVersion], config).testSuite()
+})
+
+describe('Kafka operation binding v0.6.0 errorTopics', () => {
+  const schema = require(`@bindings/kafka/0.6.0/operation.json`);
+
+  it('allows retry and dlq references', () => TestHelper.objectIsValid(
+    schema,
+    {
+      "errorTopics": {
+        "addressTemplate": "${groupId}.__.${channel.address}.${suffix}",
+        "retryTopics": 3,
+        "retry": {
+          "$ref": "#/components/error-topics/retry/silver"
+        },
+        "dlq": {
+          "$ref": "#/components/error-topics/dlq/compliance"
+        }
+      },
+      "bindingVersion": "0.6.0"
+    },
+  ));
+
+  it('requires retryTopics when retry is present', () => {
+    const validator = TestHelper.validator(schema);
+    const validationResult = validator({
+      "errorTopics": {
+        "addressTemplate": "${groupId}.__.${channel.address}.${suffix}",
+        "retry": {
+          "partitions": 1
+        }
+      },
+      "bindingVersion": "0.6.0"
+    });
+
+    assert(validationResult === false, 'Object MUST NOT be valid');
+    assert(validator.errors.some(error => error.message === "must have required property 'retryTopics'"));
+  });
+})
+
+describe('Kafka operation binding v0.6.0 bindingVersion', () => {
+  const schema = require(`@bindings/kafka/0.6.0/operation.json`);
+
+  it('rejects previous bindingVersion values', () => TestHelper.objectIsNotValid(
+    schema,
+    {
+      "transactional": true,
+      "bindingVersion": "0.5.0"
+    },
+    [
+      "must be equal to one of the allowed values"
+    ]
+  ));
 })

--- a/test/bindings/kafka/kafka operation binding.test.mjs
+++ b/test/bindings/kafka/kafka operation binding.test.mjs
@@ -164,18 +164,11 @@ let data = {
     require(`@bindings/kafka/0.6.0/operation.json`),
     [
       {
-        "groupId": {
-          "type": "string",
-          "enum": [
-            "myGroupId"
-          ]
-        },
-        "clientId": {
-          "type": "string",
-          "enum": [
-            "myClientId"
-          ]
-        },
+        "groupId": "myGroupId",
+        "clientId": [
+          "myClientId",
+          "myOtherClientId"
+        ],
         "bindingVersion": "0.6.0"
       },
       {
@@ -276,6 +269,105 @@ describe('Kafka operation binding v0.6.0 errorTopics', () => {
 
     assert(validationResult === false, 'Object MUST NOT be valid');
     assert(validator.errors.some(error => error.message === "must have required property 'retryTopics'"));
+  });
+})
+
+describe('Kafka operation binding v0.6.0 groupId and clientId', () => {
+  const schema = require(`@bindings/kafka/0.6.0/operation.json`);
+
+  it('allows string values', () => TestHelper.objectIsValid(
+    schema,
+    {
+      "groupId": "payments-consumer-group",
+      "clientId": "payments-client",
+      "bindingVersion": "0.6.0"
+    },
+  ));
+
+  it('allows unique arrays of strings', () => TestHelper.objectIsValid(
+    schema,
+    {
+      "groupId": [
+        "payments-consumer-group",
+        "payments-consumer-group-replay"
+      ],
+      "clientId": [
+        "payments-client",
+        "payments-client-replay"
+      ],
+      "bindingVersion": "0.6.0"
+    },
+  ));
+
+  it('allows schema objects', () => TestHelper.objectIsValid(
+    schema,
+    {
+      "groupId": {
+        "type": "string",
+        "enum": [
+          "payments-consumer-group"
+        ]
+      },
+      "clientId": {
+        "type": "string",
+        "enum": [
+          "payments-client"
+        ]
+      },
+      "bindingVersion": "0.6.0"
+    },
+  ));
+
+  it('allows references', () => TestHelper.objectIsValid(
+    schema,
+    {
+      "groupId": {
+        "$ref": "#/components/schemas/kafkaGroupId"
+      },
+      "clientId": {
+        "$ref": "#/components/schemas/kafkaClientId"
+      },
+      "bindingVersion": "0.6.0"
+    },
+  ));
+
+  it('rejects empty arrays', () => {
+    const validator = TestHelper.validator(schema);
+    const validationResult = validator({
+      "groupId": [],
+      "bindingVersion": "0.6.0"
+    });
+
+    assert(validationResult === false, 'Object MUST NOT be valid');
+    assert(validator.errors.some(error => error.message === "must NOT have fewer than 1 items"));
+  });
+
+  it('rejects arrays with non-string items', () => {
+    const validator = TestHelper.validator(schema);
+    const validationResult = validator({
+      "clientId": [
+        "payments-client",
+        1
+      ],
+      "bindingVersion": "0.6.0"
+    });
+
+    assert(validationResult === false, 'Object MUST NOT be valid');
+    assert(validator.errors.some(error => error.message === "must be string"));
+  });
+
+  it('rejects arrays with duplicate values', () => {
+    const validator = TestHelper.validator(schema);
+    const validationResult = validator({
+      "groupId": [
+        "payments-consumer-group",
+        "payments-consumer-group"
+      ],
+      "bindingVersion": "0.6.0"
+    });
+
+    assert(validationResult === false, 'Object MUST NOT be valid');
+    assert(validator.errors.some(error => error.message.includes("must NOT have duplicate items")));
   });
 })
 

--- a/test/bindings/kafka/kafka server binding.test.mjs
+++ b/test/bindings/kafka/kafka server binding.test.mjs
@@ -3,7 +3,8 @@ import {
   JsonSchemaTestSuiteConfig,
   JsonSchemaTestSuiteData
 } from '@test/definitions/base-schema-test.mjs';
-import {describe} from 'vitest';
+import TestHelper from '@test/test-helper';
+import {describe, it} from 'vitest';
 
 const config = new JsonSchemaTestSuiteConfig(
   false,
@@ -91,12 +92,54 @@ let data = {
       "ext-number": 1
     }
   ),
+  "0.6.0": new JsonSchemaTestSuiteData(
+    require(`@bindings/kafka/0.6.0/server.json`),
+    [
+      {
+        "schemaRegistryUrl": "https://my-schema-registry.com",
+        "schemaRegistryVendor": "confluent",
+        "bindingVersion": "0.6.0"
+      }
+    ],
+    {},
+    {},
+    {
+      "x-number": 0,
+      "x-string": "",
+      "x-object": {
+        "property": {}
+      }
+    },
+    {
+      "x-number": 0,
+      "x-string": "",
+      "x-object": {
+        "property": {}
+      },
+      "ext-number": 1
+    }
+  ),
 }
 
 describe.each([
   '0.3.0',
   '0.4.0',
   '0.5.0',
-])('Kafka operation binding v%s', (bindingVersion) => {
+  '0.6.0',
+])('Kafka server binding v%s', (bindingVersion) => {
   new JsonSchemaTestSuite(data[bindingVersion], config).testSuite()
+})
+
+describe('Kafka server binding v0.6.0 bindingVersion', () => {
+  const schema = require(`@bindings/kafka/0.6.0/server.json`);
+
+  it('rejects previous bindingVersion values', () => TestHelper.objectIsNotValid(
+    schema,
+    {
+      "bindingVersion": "0.5.0"
+    },
+    [
+      "must be equal to one of the allowed values"
+    ]
+  ));
 })


### PR DESCRIPTION
NOTE: this PR is stacked on https://github.com/asyncapi/spec-json-schemas/pull/645

**Description**

Implements [FEATURE] Kafka operations: allow groupId and clientId to be a string or array of strings
 asyncapi/bindings#303

adding support for plain values in `clientId` and `groupId`

```
# what you have to write today
groupId:
  type: string
  enum: ['payments-consumer-group']
 
# what you actually mean
groupId: 'payments-consumer-group'
```

**Related issue(s)**
Fixes https://github.com/asyncapi/bindings/issues/303