### PR TITLE
feat: add retry and dead-letter operation schemas

### DIFF
--- a/definitions/3.0.0/exponentialRetryStrategy.json
+++ b/definitions/3.0.0/exponentialRetryStrategy.json
@@ -1,0 +1,34 @@
+{
+  "type": "object",
+  "description": "Describes a retry strategy with an exponentially increasing delay.",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+    }
+  },
+  "required": ["type", "initialDelay", "multiplier"],
+  "properties": {
+    "type": {
+      "description": "Identifies this as an exponential retry strategy.",
+      "const": "exponential"
+    },
+    "initialDelay": {
+      "type": "string",
+      "description": "The delay before the first retry attempt.",
+      "pattern": "^PT(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:[.,]\\d+)?S)?$"
+    },
+    "multiplier": {
+      "type": "number",
+      "description": "The value by which the delay is multiplied after each retry attempt.",
+      "exclusiveMinimum": 0
+    },
+    "maxDelay": {
+      "type": "string",
+      "description": "The maximum delay between retry attempts.",
+      "pattern": "^PT(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:[.,]\\d+)?S)?$"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/3.0.0/exponentialRetryStrategy.json"
+}

--- a/definitions/3.0.0/fixedRetryStrategy.json
+++ b/definitions/3.0.0/fixedRetryStrategy.json
@@ -1,0 +1,24 @@
+{
+  "type": "object",
+  "description": "Describes a retry strategy with a fixed delay.",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+    }
+  },
+  "required": ["type", "delay"],
+  "properties": {
+    "type": {
+      "description": "Identifies this as a fixed retry strategy.",
+      "const": "fixed"
+    },
+    "delay": {
+      "type": "string",
+      "description": "The delay between every retry attempt.",
+      "pattern": "^PT(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:[.,]\\d+)?S)?$"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/3.0.0/fixedRetryStrategy.json"
+}

--- a/definitions/3.0.0/linearRetryStrategy.json
+++ b/definitions/3.0.0/linearRetryStrategy.json
@@ -1,0 +1,34 @@
+{
+  "type": "object",
+  "description": "Describes a retry strategy with a linearly increasing delay.",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+    }
+  },
+  "required": ["type", "initialDelay", "delayIncrement"],
+  "properties": {
+    "type": {
+      "description": "Identifies this as a linear retry strategy.",
+      "const": "linear"
+    },
+    "initialDelay": {
+      "type": "string",
+      "description": "The delay before the first retry attempt.",
+      "pattern": "^PT(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:[.,]\\d+)?S)?$"
+    },
+    "delayIncrement": {
+      "type": "string",
+      "description": "The amount added to the delay after each retry attempt.",
+      "pattern": "^PT(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:[.,]\\d+)?S)?$"
+    },
+    "maxDelay": {
+      "type": "string",
+      "description": "The maximum delay between retry attempts.",
+      "pattern": "^PT(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:[.,]\\d+)?S)?$"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/3.0.0/linearRetryStrategy.json"
+}

--- a/definitions/3.0.0/operation.json
+++ b/definitions/3.0.0/operation.json
@@ -37,6 +37,28 @@
         }
       ]
     },
+    "retry": {
+      "description": "The retry route and policy for a receive operation when processing does not complete successfully.",
+      "oneOf": [
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+        },
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/operationRetry.json"
+        }
+      ]
+    },
+    "deadLetter": {
+      "description": "The dead-letter route for a receive operation when processing cannot be recovered.",
+      "oneOf": [
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+        },
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/operationDeadLetter.json"
+        }
+      ]
+    },
     "traits": {
       "type": "array",
       "description": "A list of traits to apply to the operation object. Traits MUST be merged using traits merge mechanism. The resulting object MUST be a valid Operation Object.",
@@ -102,6 +124,32 @@
       ]
     }
   },
+  "allOf": [
+    {
+      "if": {
+        "required": ["retry"]
+      },
+      "then": {
+        "properties": {
+          "action": {
+            "const": "receive"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["deadLetter"]
+      },
+      "then": {
+        "properties": {
+          "action": {
+            "const": "receive"
+          }
+        }
+      }
+    }
+  ],
   "example": {
     "$ref": "http://asyncapi.com/examples/3.0.0/operation.json"
   },

--- a/definitions/3.0.0/operationDeadLetter.json
+++ b/definitions/3.0.0/operationDeadLetter.json
@@ -1,0 +1,32 @@
+{
+  "type": "object",
+  "description": "Describes the dead-letter path for a receive operation.",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+    }
+  },
+  "required": ["channel", "messages"],
+  "properties": {
+    "channel": {
+      "description": "A reference to the channel to which dead-letter messages are sent.",
+      "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+    },
+    "messages": {
+      "type": "array",
+      "description": "The dead-letter messages available on the referenced channel.",
+      "minItems": 1,
+      "items": {
+        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+      }
+    },
+    "maxWaitTime": {
+      "type": "string",
+      "description": "The maximum time an implementation waits for a dead-letter message to appear.",
+      "pattern": "^PT(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:[.,]\\d+)?S)?$"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/3.0.0/operationDeadLetter.json"
+}

--- a/definitions/3.0.0/operationRetry.json
+++ b/definitions/3.0.0/operationRetry.json
@@ -1,0 +1,46 @@
+{
+  "type": "object",
+  "description": "Describes the retry path for a receive operation.",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+    }
+  },
+  "required": ["channel", "messages", "maxAttempts", "strategy"],
+  "properties": {
+    "channel": {
+      "description": "A reference to the channel to which retry messages are sent.",
+      "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+    },
+    "messages": {
+      "type": "array",
+      "description": "The retry messages available on the referenced channel.",
+      "minItems": 1,
+      "items": {
+        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+      }
+    },
+    "maxAttempts": {
+      "type": "integer",
+      "description": "The maximum number of retry attempts.",
+      "minimum": 1
+    },
+    "strategy": {
+      "description": "The delay policy applied between retry attempts.",
+      "oneOf": [
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/fixedRetryStrategy.json"
+        },
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/linearRetryStrategy.json"
+        },
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/exponentialRetryStrategy.json"
+        }
+      ]
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/3.0.0/operationRetry.json"
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "@asyncapi/specs",
   "version": "6.11.1",
   "description": "AsyncAPI schema versions",
+  "engines": {
+    "node": ">=24"
+  },
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {

--- a/schemas/3.0.0-without-$id.json
+++ b/schemas/3.0.0-without-$id.json
@@ -6534,6 +6534,28 @@
                         }
                     ]
                 },
+                "retry": {
+                    "description": "The retry route and policy for a receive operation when processing does not complete successfully.",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Reference"
+                        },
+                        {
+                            "$ref": "#/definitions/operationRetry"
+                        }
+                    ]
+                },
+                "deadLetter": {
+                    "description": "The dead-letter route for a receive operation when processing cannot be recovered.",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Reference"
+                        },
+                        {
+                            "$ref": "#/definitions/operationDeadLetter"
+                        }
+                    ]
+                },
                 "traits": {
                     "type": "array",
                     "description": "A list of traits to apply to the operation object. Traits MUST be merged using traits merge mechanism. The resulting object MUST be a valid Operation Object.",
@@ -6599,6 +6621,36 @@
                     ]
                 }
             },
+            "allOf": [
+                {
+                    "if": {
+                        "required": [
+                            "retry"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "action": {
+                                "const": "receive"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "required": [
+                            "deadLetter"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "action": {
+                                "const": "receive"
+                            }
+                        }
+                    }
+                }
+            ],
             "examples": [
                 {
                     "title": "User sign up",
@@ -6719,6 +6771,185 @@
                     "location": "$message.header#/replyTo"
                 }
             ]
+        },
+        "operationRetry": {
+            "type": "object",
+            "description": "Describes the retry path for a receive operation.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "required": [
+                "channel",
+                "messages",
+                "maxAttempts",
+                "strategy"
+            ],
+            "properties": {
+                "channel": {
+                    "description": "A reference to the channel to which retry messages are sent.",
+                    "$ref": "#/definitions/Reference"
+                },
+                "messages": {
+                    "type": "array",
+                    "description": "The retry messages available on the referenced channel.",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/Reference"
+                    }
+                },
+                "maxAttempts": {
+                    "type": "integer",
+                    "description": "The maximum number of retry attempts.",
+                    "minimum": 1
+                },
+                "strategy": {
+                    "description": "The delay policy applied between retry attempts.",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/fixedRetryStrategy"
+                        },
+                        {
+                            "$ref": "#/definitions/linearRetryStrategy"
+                        },
+                        {
+                            "$ref": "#/definitions/exponentialRetryStrategy"
+                        }
+                    ]
+                }
+            }
+        },
+        "fixedRetryStrategy": {
+            "type": "object",
+            "description": "Describes a retry strategy with a fixed delay.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "required": [
+                "type",
+                "delay"
+            ],
+            "properties": {
+                "type": {
+                    "description": "Identifies this as a fixed retry strategy.",
+                    "const": "fixed"
+                },
+                "delay": {
+                    "type": "string",
+                    "description": "The delay between every retry attempt.",
+                    "pattern": "^PT(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:[.,]\\d+)?S)?$"
+                }
+            }
+        },
+        "linearRetryStrategy": {
+            "type": "object",
+            "description": "Describes a retry strategy with a linearly increasing delay.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "required": [
+                "type",
+                "initialDelay",
+                "delayIncrement"
+            ],
+            "properties": {
+                "type": {
+                    "description": "Identifies this as a linear retry strategy.",
+                    "const": "linear"
+                },
+                "initialDelay": {
+                    "type": "string",
+                    "description": "The delay before the first retry attempt.",
+                    "pattern": "^PT(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:[.,]\\d+)?S)?$"
+                },
+                "delayIncrement": {
+                    "type": "string",
+                    "description": "The amount added to the delay after each retry attempt.",
+                    "pattern": "^PT(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:[.,]\\d+)?S)?$"
+                },
+                "maxDelay": {
+                    "type": "string",
+                    "description": "The maximum delay between retry attempts.",
+                    "pattern": "^PT(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:[.,]\\d+)?S)?$"
+                }
+            }
+        },
+        "exponentialRetryStrategy": {
+            "type": "object",
+            "description": "Describes a retry strategy with an exponentially increasing delay.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "required": [
+                "type",
+                "initialDelay",
+                "multiplier"
+            ],
+            "properties": {
+                "type": {
+                    "description": "Identifies this as an exponential retry strategy.",
+                    "const": "exponential"
+                },
+                "initialDelay": {
+                    "type": "string",
+                    "description": "The delay before the first retry attempt.",
+                    "pattern": "^PT(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:[.,]\\d+)?S)?$"
+                },
+                "multiplier": {
+                    "type": "number",
+                    "description": "The value by which the delay is multiplied after each retry attempt.",
+                    "exclusiveMinimum": 0
+                },
+                "maxDelay": {
+                    "type": "string",
+                    "description": "The maximum delay between retry attempts.",
+                    "pattern": "^PT(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:[.,]\\d+)?S)?$"
+                }
+            }
+        },
+        "operationDeadLetter": {
+            "type": "object",
+            "description": "Describes the dead-letter path for a receive operation.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "required": [
+                "channel",
+                "messages"
+            ],
+            "properties": {
+                "channel": {
+                    "description": "A reference to the channel to which dead-letter messages are sent.",
+                    "$ref": "#/definitions/Reference"
+                },
+                "messages": {
+                    "type": "array",
+                    "description": "The dead-letter messages available on the referenced channel.",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/Reference"
+                    }
+                },
+                "maxWaitTime": {
+                    "type": "string",
+                    "description": "The maximum time an implementation waits for a dead-letter message to appear.",
+                    "pattern": "^PT(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:[.,]\\d+)?S)?$"
+                }
+            }
         },
         "operationTrait": {
             "type": "object",

--- a/schemas/3.0.0.json
+++ b/schemas/3.0.0.json
@@ -6622,6 +6622,28 @@
                         }
                     ]
                 },
+                "retry": {
+                    "description": "The retry route and policy for a receive operation when processing does not complete successfully.",
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/operationRetry.json"
+                        }
+                    ]
+                },
+                "deadLetter": {
+                    "description": "The dead-letter route for a receive operation when processing cannot be recovered.",
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/operationDeadLetter.json"
+                        }
+                    ]
+                },
                 "traits": {
                     "type": "array",
                     "description": "A list of traits to apply to the operation object. Traits MUST be merged using traits merge mechanism. The resulting object MUST be a valid Operation Object.",
@@ -6687,6 +6709,36 @@
                     ]
                 }
             },
+            "allOf": [
+                {
+                    "if": {
+                        "required": [
+                            "retry"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "action": {
+                                "const": "receive"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "required": [
+                            "deadLetter"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "action": {
+                                "const": "receive"
+                            }
+                        }
+                    }
+                }
+            ],
             "examples": [
                 {
                     "title": "User sign up",
@@ -6809,6 +6861,190 @@
                     "location": "$message.header#/replyTo"
                 }
             ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/operationRetry.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/operationRetry.json",
+            "type": "object",
+            "description": "Describes the retry path for a receive operation.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "required": [
+                "channel",
+                "messages",
+                "maxAttempts",
+                "strategy"
+            ],
+            "properties": {
+                "channel": {
+                    "description": "A reference to the channel to which retry messages are sent.",
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                },
+                "messages": {
+                    "type": "array",
+                    "description": "The retry messages available on the referenced channel.",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                    }
+                },
+                "maxAttempts": {
+                    "type": "integer",
+                    "description": "The maximum number of retry attempts.",
+                    "minimum": 1
+                },
+                "strategy": {
+                    "description": "The delay policy applied between retry attempts.",
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/fixedRetryStrategy.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/linearRetryStrategy.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/exponentialRetryStrategy.json"
+                        }
+                    ]
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/3.0.0/fixedRetryStrategy.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/fixedRetryStrategy.json",
+            "type": "object",
+            "description": "Describes a retry strategy with a fixed delay.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "required": [
+                "type",
+                "delay"
+            ],
+            "properties": {
+                "type": {
+                    "description": "Identifies this as a fixed retry strategy.",
+                    "const": "fixed"
+                },
+                "delay": {
+                    "type": "string",
+                    "description": "The delay between every retry attempt.",
+                    "pattern": "^PT(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:[.,]\\d+)?S)?$"
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/3.0.0/linearRetryStrategy.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/linearRetryStrategy.json",
+            "type": "object",
+            "description": "Describes a retry strategy with a linearly increasing delay.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "required": [
+                "type",
+                "initialDelay",
+                "delayIncrement"
+            ],
+            "properties": {
+                "type": {
+                    "description": "Identifies this as a linear retry strategy.",
+                    "const": "linear"
+                },
+                "initialDelay": {
+                    "type": "string",
+                    "description": "The delay before the first retry attempt.",
+                    "pattern": "^PT(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:[.,]\\d+)?S)?$"
+                },
+                "delayIncrement": {
+                    "type": "string",
+                    "description": "The amount added to the delay after each retry attempt.",
+                    "pattern": "^PT(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:[.,]\\d+)?S)?$"
+                },
+                "maxDelay": {
+                    "type": "string",
+                    "description": "The maximum delay between retry attempts.",
+                    "pattern": "^PT(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:[.,]\\d+)?S)?$"
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/3.0.0/exponentialRetryStrategy.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/exponentialRetryStrategy.json",
+            "type": "object",
+            "description": "Describes a retry strategy with an exponentially increasing delay.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "required": [
+                "type",
+                "initialDelay",
+                "multiplier"
+            ],
+            "properties": {
+                "type": {
+                    "description": "Identifies this as an exponential retry strategy.",
+                    "const": "exponential"
+                },
+                "initialDelay": {
+                    "type": "string",
+                    "description": "The delay before the first retry attempt.",
+                    "pattern": "^PT(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:[.,]\\d+)?S)?$"
+                },
+                "multiplier": {
+                    "type": "number",
+                    "description": "The value by which the delay is multiplied after each retry attempt.",
+                    "exclusiveMinimum": 0
+                },
+                "maxDelay": {
+                    "type": "string",
+                    "description": "The maximum delay between retry attempts.",
+                    "pattern": "^PT(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:[.,]\\d+)?S)?$"
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/3.0.0/operationDeadLetter.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/operationDeadLetter.json",
+            "type": "object",
+            "description": "Describes the dead-letter path for a receive operation.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "required": [
+                "channel",
+                "messages"
+            ],
+            "properties": {
+                "channel": {
+                    "description": "A reference to the channel to which dead-letter messages are sent.",
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                },
+                "messages": {
+                    "type": "array",
+                    "description": "The dead-letter messages available on the referenced channel.",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                    }
+                },
+                "maxWaitTime": {
+                    "type": "string",
+                    "description": "The maximum time an implementation waits for a dead-letter message to appear.",
+                    "pattern": "^PT(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:[.,]\\d+)?S)?$"
+                }
+            }
         },
         "http://asyncapi.com/definitions/3.0.0/operationTrait.json": {
             "$id": "http://asyncapi.com/definitions/3.0.0/operationTrait.json",

--- a/test/ajv-schemes.js
+++ b/test/ajv-schemes.js
@@ -91,10 +91,13 @@ function schemesV3_0_0(ajv) {
   ajv.addSchema(require('@definitions/3.0.0/contact.json'));
   ajv.addSchema(require('@definitions/3.0.0/correlationId.json'));
   ajv.addSchema(require('@definitions/3.0.0/externalDocs.json'));
+  ajv.addSchema(require('@definitions/3.0.0/exponentialRetryStrategy.json'));
+  ajv.addSchema(require('@definitions/3.0.0/fixedRetryStrategy.json'));
   ajv.addSchema(require('@definitions/3.0.0/HTTPSecurityScheme.json'));
   ajv.addSchema(require('@definitions/3.0.0/info.json'));
   ajv.addSchema(require('@definitions/3.0.0/infoExtensions.json'));
   ajv.addSchema(require('@definitions/3.0.0/license.json'));
+  ajv.addSchema(require('@definitions/3.0.0/linearRetryStrategy.json'));
   ajv.addSchema(require('@definitions/3.0.0/messageBindingsObject.json'));
   ajv.addSchema(require('@definitions/3.0.0/messageExampleObject.json'));
   ajv.addSchema(require('@definitions/3.0.0/messageObject.json'));
@@ -107,8 +110,10 @@ function schemesV3_0_0(ajv) {
   ajv.addSchema(require('@definitions/3.0.0/oauth2Scopes.json'));
   ajv.addSchema(require('@definitions/3.0.0/openIdConnect.json'));
   ajv.addSchema(require('@definitions/3.0.0/operationBindingsObject.json'));
+  ajv.addSchema(require('@definitions/3.0.0/operationDeadLetter.json'));
   ajv.addSchema(require('@definitions/3.0.0/operationReply.json'));
   ajv.addSchema(require('@definitions/3.0.0/operationReplyAddress.json'));
+  ajv.addSchema(require('@definitions/3.0.0/operationRetry.json'));
   ajv.addSchema(require('@definitions/3.0.0/operation.json'));
   ajv.addSchema(require('@definitions/3.0.0/operations.json'));
   ajv.addSchema(require('@definitions/3.0.0/operationTrait.json'));

--- a/test/definitions/3.0.0/models/operation/operation.test.mjs
+++ b/test/definitions/3.0.0/models/operation/operation.test.mjs
@@ -35,6 +35,40 @@ const data = new JsonSchemaTestSuiteData(
         }
       },
       "traits": [{ "$ref": "#/components/operationTraits/kafka" }]
+    },
+    {
+      "channel": {
+        "$ref": "#/channels/userSignup"
+      },
+      "action": "receive",
+      "retry": {
+        "channel": {
+          "$ref": "#/channels/userSignupRetries"
+        },
+        "messages": [
+          {
+            "$ref": "#/channels/userSignupRetries/messages/userSignupRetry"
+          }
+        ],
+        "maxAttempts": 3,
+        "strategy": {
+          "type": "exponential",
+          "initialDelay": "PT1S",
+          "multiplier": 2,
+          "maxDelay": "PT1M"
+        }
+      },
+      "deadLetter": {
+        "channel": {
+          "$ref": "#/channels/userSignupDeadLetters"
+        },
+        "messages": [
+          {
+            "$ref": "#/channels/userSignupDeadLetters/messages/userSignupDeadLetter"
+          }
+        ],
+        "maxWaitTime": "PT15S"
+      }
     }
   ],
   {

--- a/test/definitions/3.0.0/models/operation/retry and dead letter.test.mjs
+++ b/test/definitions/3.0.0/models/operation/retry and dead letter.test.mjs
@@ -1,0 +1,72 @@
+import {describe, expect, it} from 'vitest';
+import TestHelper from '@test/test-helper';
+
+const operationSchema = require('@definitions/3.0.0/operation.json');
+
+const retryRoute = {
+  "channel": {"$ref": "#/channels/retries"},
+  "messages": [{"$ref": "#/channels/retries/messages/retry"}],
+  "maxAttempts": 3,
+  "strategy": {
+    "type": "linear",
+    "initialDelay": "PT5S",
+    "delayIncrement": "PT10S",
+    "maxDelay": "PT1M"
+  }
+};
+
+const deadLetterRoute = {
+  "channel": {"$ref": "#/channels/deadLetters"},
+  "messages": [{"$ref": "#/channels/deadLetters/messages/deadLetter"}],
+  "maxWaitTime": "PT15M"
+};
+
+const operationWith = (overrides) => ({
+  "action": "receive",
+  "channel": {"$ref": "#/channels/orders"},
+  ...overrides
+});
+
+describe('Operation retry and dead-letter paths', () => {
+  it('accepts fixed, linear, and exponential retry strategies', () => {
+    const strategies = [
+      {"type": "fixed", "delay": "PT30S"},
+      retryRoute.strategy,
+      {"type": "exponential", "initialDelay": "PT1S", "multiplier": 2, "maxDelay": "PT1H"}
+    ];
+
+    for (const strategy of strategies) {
+      const validate = TestHelper.validator(operationSchema);
+      expect(validate(operationWith({"retry": {...retryRoute, strategy}}))).toBe(true);
+    }
+  });
+
+  it('accepts a dead-letter path with an ISO 8601 wait time', () => {
+    const validate = TestHelper.validator(operationSchema);
+    expect(validate(operationWith({"deadLetter": deadLetterRoute}))).toBe(true);
+  });
+
+  it('rejects non-duration retry and dead-letter wait values', () => {
+    const invalidDurationValues = ["15", "P1D", "PT"];
+
+    for (const duration of invalidDurationValues) {
+      const retryValidation = TestHelper.validator(operationSchema);
+      expect(retryValidation(operationWith({
+        "retry": {...retryRoute, "strategy": {"type": "fixed", "delay": duration}}
+      }))).toBe(false);
+
+      const deadLetterValidation = TestHelper.validator(operationSchema);
+      expect(deadLetterValidation(operationWith({
+        "deadLetter": {...deadLetterRoute, "maxWaitTime": duration}
+      }))).toBe(false);
+    }
+  });
+
+  it('rejects retry and dead-letter paths on send operations', () => {
+    const validate = TestHelper.validator(operationSchema);
+    expect(validate({
+      ...operationWith({"retry": retryRoute, "deadLetter": deadLetterRoute}),
+      "action": "send"
+    })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Related issue(s)

Closes #660

Related specification proposal: https://github.com/asyncapi/spec/issues/1234

## What changed

Adds AsyncAPI 3.0 JSON Schema support for optional `retry` and `deadLetter` paths on receive operations.

## Why

The proposed contract needs schema validation so parsers and tooling can recognize retry routing, dead-letter routing, and their timing policies.

## Implementation

- Adds retry and dead-letter route definitions with channel and message references.
- Adds fixed, linear, and exponential tagged retry strategies.
- Validates ISO 8601 durations limited to hours, minutes, and seconds.
- Restricts retry and dead-letter paths to receive operations.
- Regenerates the bundled 3.0.0 schemas.

## Validation

- Full test suite
- Schema validation
- Lint
- Diff check

## RFC status

This draft implements JSON Schema support for the associated RFC 1 proposal. Naming and detailed semantics remain open for community discussion.